### PR TITLE
Added support to allow the 'open' option to take a callback

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -218,17 +218,19 @@
 		if (callback) {
 			options.onComplete = callback;
 		}
-		
+
 		if (!$this[0] || $this.selector === undefined) { // detects $.colorbox() and $.fn.colorbox()
 			$this = $('<a/>');
 			options.open = true; // assume an immediate open
-		}
+    } else {
+      options.open = (typeof(options.open) == 'function') ? options.open() : options.open;
+    }
 		
 		$this.each(function () {
 			$(this).data(colorbox, $.extend({}, $(this).data(colorbox) || defaults, options)).addClass(boxElement);
 		});
 		
-		if (options.open) {
+    if (options.open) {
 			launch($this[0]);
 		}
 		


### PR DESCRIPTION
We ran into a scenario where we wanted the overlay to load on page load, but not reload on subsequent page requests (e.g. paginated search results).  Per the documentation, we expected these options to be able to take a callback in place of a static value:

> ColorBox can accept a function in place of a static value:

```
$("a[rel='example']").colorbox({title: function(){
    var url = $(this).attr('href');
    return '<a href="'+url+'" target="_blank">Open In New Window</a>';
}});
```

We found that this behavior wasn't available for the 'open' option -- this commit adds that behavior.
