### PR TITLE
Use delegate(), allow href to be set to a DOM node/jQuery instance

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -139,7 +139,8 @@
 			}
 		}
 		settings.rel = settings.rel || element.rel || 'nofollow';
-		settings.href = $.trim(settings.href || $(element).attr('href'));
+		if (!settings.href || typeof(settings.href) == "string")
+			settings.href = $.trim(settings.href || $(element).attr('href'));
 		settings.title = settings.title || element.title;
 	}
 


### PR DESCRIPTION
Hi,

I have two small patches on master of my clone:

The first one fixes a HUGE performance issue in IE6 and 7 on big pages:

the issue with live() is that it still selects all the elements only to
then discard the selection afterwards. This a) wastes resources and b)
kills IE<8 on really big pages as it doesn't have getElementsByClassName
which causes jQuery to select all elements on check for the class if you
do a $(.classname) selection.

$(document).delegate(...) only selects document which is as fast as you
can possibly be.

The second patch allows the href element of the options object to be set to a DOM node or jQuery instance. This has already worked in previous versions (which is why I ran into this issue now) and it still works fine as long as you don't run $.trim() over the jQuery instance :p
