### PR TITLE
Allow passing in DOM object directly to colorbox which works in the older version of colorbox

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -140,7 +140,7 @@
 		}
 		var href = settings.href || $(element).attr('href');
 		if (typeof href == "string") {
-		  settings.href = $.trim(settings.href || $(element).attr('href'));
+		  settings.href = $.trim(href);
 		}
 		settings.rel = settings.rel || element.rel || 'nofollow';
 		settings.title = settings.title || element.title;


### PR DESCRIPTION
The fix is to only trim settings.href if it is a string. This allow to pass in a jQuery object as href.
I use colorbox to display a dynamically-generated DOM element and in the old version of colorbox, I can just pass the DOM object directly to colorbox
