### PR TITLE
Fix to handle hidden inline elements.

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -20,6 +20,7 @@
 		scalePhotos: true,
 		scrolling: true,
 		inline: false,
+		hideInlineContent: true,
 		html: false,
 		iframe: false,
 		fastIframe: true,
@@ -724,7 +725,11 @@
 		if (settings.inline) {
 			// Inserts an empty placeholder where inline content is being pulled from.
 			// An event is bound to put inline content back when ColorBox closes or loads new content.
+			$(href).show();
 			$div().hide().insertBefore($(href)[0]).one(event_purge, function () {
+				if(settings.hideInlineContent) {
+					$(href).hide();
+				}
 				$(this).replaceWith($loaded.children());
 			});
 			prep($(href));


### PR DESCRIPTION
A simple fix, so we don't need to wrap the inline element in a '&lt;div style="display:none"&gt;&lt;/div&gt;' to hide it.

A new option named 'hideInlineContent' (default value is true) was added. If, for some reason, you don't need the inline element to be hidden, just change it to false.
