### PR TITLE
Fix $.colorbox.resize() to not clobber nested/dynamically added content...

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -516,9 +516,8 @@
 				settings.h = setSize(options.innerHeight, 'y');
 			}
 			if (!options.innerHeight && !options.height) {				
-				var $child = $loaded.wrapInner("<div style='overflow:auto'></div>").children(); // temporary wrapper to get an accurate estimate of just how high the total content should be.
-				settings.h = $child.height();
-				$child.replaceWith($child.children()); // ditch the temporary wrapper div used in height calculation
+				$loaded.css("height", "auto");
+				settings.h = $loaded.height();
 			}
 			$loaded.css({height: settings.h});
 			


### PR DESCRIPTION
Hi,

I was dynamically updating the content rendered in the onComplete function - however calling resize() would clobbering any HTML (textnodes) if you also had a other children such as a <div> due to the way resize() was implemented. 

I reworked the resize() function so that the estimation function temporarily changes the height of the cboxLoadedContent div to auto, grabs the height, and then sets the height statically to the calculated value - allowing the browser to do all the work.

This has a number of advantages including not disturbing the DOM or any handlers you may have setup on the DOM  elements - not to mention a little more efficient since you skip the call to wrapInner()

I tested this solution in IE7/IE8/IE9/Firefox/Chrome and all appeared to behave correctly.  

Love colorbox - it was just what I was looking for.

Thanks,
Stephen
