### PR TITLE
Introduced onBeforeComplete event

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -43,6 +43,7 @@
 		slideshowStop: "stop slideshow",
 		onOpen: false,
 		onLoad: false,
+		onBeforeComplete: false,
 		onComplete: false,
 		onCleanup: false,
 		onClosed: false,
@@ -65,6 +66,7 @@
 	// Events	
 	event_open = prefix + '_open',
 	event_load = prefix + '_load',
+	event_before_complete = prefix + '_before_complete',
 	event_complete = prefix + '_complete',
 	event_cleanup = prefix + '_cleanup',
 	event_closed = prefix + '_closed',
@@ -583,6 +585,7 @@
             }
             
             complete = function () {
+                trigger(event_before_complete, settings.onBeforeComplete);
                 clearTimeout(loadingTimer);
                 $loadingOverlay.hide();
                 trigger(event_complete, settings.onComplete);


### PR DESCRIPTION
Sometimes you need to do generic things before onComplete fires, ie initialize bunch of JS classes based on received markup.

Example:
I open colorbox containing a form. All the forms on my site include:

```
$('form').attr('novalidate', 'novalidate'); // Remove modern browser automagic validation
```

I can today accomplish this by setting it in a generic `$.colorbox.settings.onComplete`, but whenever I need any additional snippet-specific lines, I must remember to duplicate the generic novalidate code.

Another gain is, that you can initialize stuff before the modal overlay is removed - making sure that the box is fully-functional by the time user can click around.

Thoughts?
