### PR TITLE
Fixes incorrect IE scroll value

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -86,6 +86,7 @@
 	$bottomBorder,
 	$related,
 	$window,
+	$html,
 	$loaded,
 	$loadingBay,
 	$loadingOverlay,
@@ -323,6 +324,7 @@
 	publicMethod.init = function () {
 		// Create & Append jQuery Objects
 		$window = $(window);
+		$html = $('html');
 		$box = $div().attr({id: colorbox, 'class': isIE ? prefix + (isIE6 ? 'IE6' : 'IE') : ''});
 		$overlay = $div("Overlay", isIE6 ? 'position:absolute' : '').hide();
 		
@@ -434,8 +436,8 @@
         if (settings.fixed && !isIE6) {
             $box.css({position: 'fixed'});
         } else {
-            top = $window.scrollTop();
-            left = $window.scrollLeft();
+            top = (!isIE) ? $window.scrollTop() : $html.scrollTop();
+            left = (!isIE) ? $window.scrollLeft() : $html.scrollTop();
             $box.css({position: 'absolute'});
         }
         


### PR DESCRIPTION
Checks for IE before getting the scroll values for positioning. If it's found to be IE then the scrollTop method is ran on the html tag jquery object. (instead of window, which always returns 0 in <IE9)
