### PR TITLE
Making images nicely fade out instead of instant flash to container.

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -551,7 +551,11 @@
 		
 		var callback, speed = settings.transition === "none" ? 0 : settings.speed;
 		
-		$loaded.remove();
+		if(settings.transition === "fade") {
+			$loaded.fadeOut(settings.speed, function() { $(this).remove(); });
+		} else {
+			$loaded.remove();
+		}
 		$loaded = $tag(div, 'LoadedContent').append(object);
 		
 		function getWidth() {


### PR DESCRIPTION
Hi Jack,

There's a slight problem in your colorbox script. If you choose fade for the transition effect, images get faded in, but they don't get faded out. Images are immediately deleted, and the container fades out, which can cause an annoying flashing effect.

Here's a fix, that fades out the images at the same duration that the container fades out so that there is no annoying flash.
