### PR TITLE
Cross-fade effect for colorbox content (and content only)

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -843,7 +843,7 @@
 				trigger(event_purge);
 				
 				$loaded.empty().remove();
-				$old.empty();
+				$old.remove();
 				
 				setTimeout(function () {
 					closing = false;

--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -842,8 +842,8 @@
 				
 				trigger(event_purge);
 				
-				$loaded.remove();
-				$old.remove();
+				$loaded.empty().remove();
+				$old.empty();
 				
 				setTimeout(function () {
 					closing = false;

--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -87,6 +87,7 @@
     $related,
     $window,
     $loaded,
+    $old,
     $loadingBay,
     $loadingOverlay,
     $title,
@@ -355,7 +356,8 @@
 			$overlay = $tag(div, "Overlay", isIE6 ? 'position:absolute' : '').hide();
 			$wrap = $tag(div, "Wrapper");
 			$content = $tag(div, "Content").append(
-				$loaded = $tag(div, "LoadedContent", 'width:0; height:0; overflow:hidden'),
+				$loaded = $tag(div, "LoadedContent", 'width:0; height:0; overflow:hidden; position:absolute'),
+				$old = $tag(div, "LoadedContent", 'width:0; height:0; overflow:hidden; position:absolute'),
 				$loadingOverlay = $tag(div, "LoadingOverlay").add($tag(div, "LoadingGraphic")),
 				$title = $tag(div, "Title"),
 				$current = $tag(div, "Current"),
@@ -551,7 +553,9 @@
 		
 		var callback, speed = settings.transition === "none" ? 0 : settings.speed;
 		
-		$loaded.remove();
+		$old.empty().width($loaded.width()).height($loaded.height()).show();
+		$loaded.children.appendTo($old);		
+		$loaded.remove();		
 		$loaded = $tag(div, 'LoadedContent').append(object);
 		
 		function getWidth() {
@@ -567,7 +571,7 @@
 		
 		$loaded.hide()
 		.appendTo($loadingBay.show())// content has to be appended to the DOM for accurate size calculations.
-		.css({width: getWidth(), overflow: settings.scrolling ? 'auto' : 'hidden'})
+		.css({width: getWidth(), overflow: settings.scrolling ? 'auto' : 'hidden',position:'absolute'})
 		.css({height: getHeight()})// sets the height independently from the width in case the new width influences the value of height.
 		.prependTo($content);
 		
@@ -604,14 +608,11 @@
                 clearTimeout(loadingTimer);
                 $loadingOverlay.hide();
                 trigger(event_complete, settings.onComplete);
-            };
+            };            
             
-            if (isIE) {
-                //This fadeIn helps the bicubic resampling to kick-in.
-                if (photo) {
-                    $loaded.fadeIn(100);
-                }
-            }
+            $old.fadeOut(speed);  
+            $loaded.fadeIn(speed);
+            
             
             $title.html(settings.title).add($loaded).show();
             

--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -843,6 +843,7 @@
 				trigger(event_purge);
 				
 				$loaded.remove();
+				$old.remove();
 				
 				setTimeout(function () {
 					closing = false;


### PR DESCRIPTION
Very nice cross-fade - old content fades out and new content fades in (at the same time, not fade out first, then fade in new content). Removes the annoying flashing in image gallery.
