### PR TITLE
Load Ajax into inline element on click, preserve values

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -3,7 +3,7 @@
 // Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
 
 (function ($, document, window) {
-    var 
+    var
     // Default settings object.	
     // See http://jacklmoore.com/colorbox for details.
     defaults = {
@@ -58,12 +58,12 @@
         inlineTarget: undefined,
         data: undefined
     },
-
+	
     // Abstracting the HTML and event identifiers for easy rebranding
     colorbox = 'colorbox',
     prefix = 'cbox',
     boxElement = prefix + 'Element',
-
+    
     // Events	
     event_open = prefix + '_open',
     event_load = prefix + '_load',
@@ -71,12 +71,12 @@
     event_cleanup = prefix + '_cleanup',
     event_closed = prefix + '_closed',
     event_purge = prefix + '_purge',
-
+    
     // Special Handling for IE
     isIE = $.browser.msie && !$.support.opacity, // Detects IE6,7,8.  IE9 supports opacity.  Feature detection alone gave a false positive on at least one phone browser and on some development versions of Chrome, hence the user-agent test.
     isIE6 = isIE && $.browser.version < 7,
     event_ie6 = prefix + '_IE6',
-
+    
     // Cached jQuery Object Variables
     $overlay,
     $box,
@@ -98,7 +98,7 @@
     $prev,
     $close,
     $groupControls,
-
+    
     // Variables for cached values or use across multiple functions
     settings,
     interfaceHeight,
@@ -115,248 +115,248 @@
     publicMethod,
     div = "div";
 
-    // ****************
-    // HELPER FUNCTIONS
-    // ****************
-
-    // Convience function for creating new jQuery objects
+	// ****************
+	// HELPER FUNCTIONS
+	// ****************
+    
+	// Convience function for creating new jQuery objects
     function $tag(tag, id, css) {
         var element = document.createElement(tag);
-
+        
         if (id) {
             element.id = prefix + id;
         }
-
+        
         if (css) {
             element.style.cssText = css;
         }
-
+        
         return $(element);
     }
 
-    // Determine the next and previous members in a group.
-    function getIndex(increment) {
-        var 
-		max = $related.length,
+	// Determine the next and previous members in a group.
+	function getIndex(increment) {
+		var 
+		max = $related.length, 
 		newIndex = (index + increment) % max;
+		
+		return (newIndex < 0) ? max + newIndex : newIndex;
+	}
 
-        return (newIndex < 0) ? max + newIndex : newIndex;
-    }
-
-    // Convert '%' and 'px' values to integers
-    function setSize(size, dimension) {
-        return Math.round((/%/.test(size) ? ((dimension === 'x' ? $window.width() : $window.height()) / 100) : 1) * parseInt(size, 10));
-    }
-
-    // Checks an href to see if it is a photo.
-    // There is a force photo option (photo: true) for hrefs that cannot be matched by this regex.
-    function isImage(url) {
-        return settings.photo || /\.(gif|png|jpe?g|bmp|ico)((#|\?).*)?$/i.test(url);
-    }
-
-    // Assigns function results to their respective properties
-    function makeSettings() {
+	// Convert '%' and 'px' values to integers
+	function setSize(size, dimension) {
+		return Math.round((/%/.test(size) ? ((dimension === 'x' ? $window.width() : $window.height()) / 100) : 1) * parseInt(size, 10));
+	}
+	
+	// Checks an href to see if it is a photo.
+	// There is a force photo option (photo: true) for hrefs that cannot be matched by this regex.
+	function isImage(url) {
+		return settings.photo || /\.(gif|png|jpe?g|bmp|ico)((#|\?).*)?$/i.test(url);
+	}
+	
+	// Assigns function results to their respective properties
+	function makeSettings() {
         var i;
         settings = $.extend({}, $.data(element, colorbox));
-
-        for (i in settings) {
-            if ($.isFunction(settings[i]) && i.slice(0, 2) !== 'on') { // checks to make sure the function isn't one of the callbacks, they will be handled at the appropriate time.
-                settings[i] = settings[i].call(element);
-            }
-        }
-
-        settings.rel = settings.rel || element.rel || 'nofollow';
-        settings.href = settings.href || $(element).attr('href');
-        settings.title = settings.title || element.title;
-
+        
+		for (i in settings) {
+			if ($.isFunction(settings[i]) && i.slice(0, 2) !== 'on') { // checks to make sure the function isn't one of the callbacks, they will be handled at the appropriate time.
+			    settings[i] = settings[i].call(element);
+			}
+		}
+        
+		settings.rel = settings.rel || element.rel || 'nofollow';
+		settings.href = settings.href || $(element).attr('href');
+		settings.title = settings.title || element.title;
+        
         if (typeof settings.href === "string") {
             settings.href = $.trim(settings.href);
         }
-    }
+	}
 
-    function trigger(event, callback) {
-        $.event.trigger(event);
-        if (callback) {
-            callback.call(element);
-        }
-    }
+	function trigger(event, callback) {
+		$.event.trigger(event);
+		if (callback) {
+			callback.call(element);
+		}
+	}
 
-    // Slideshow functionality
-    function slideshow() {
-        var 
+	// Slideshow functionality
+	function slideshow() {
+		var
 		timeOut,
 		className = prefix + "Slideshow_",
 		click = "click." + prefix,
 		start,
 		stop,
 		clear;
-
-        if (settings.slideshow && $related[1]) {
-            start = function () {
-                $slideshow
+		
+		if (settings.slideshow && $related[1]) {
+			start = function () {
+				$slideshow
 					.text(settings.slideshowStop)
 					.unbind(click)
 					.bind(event_complete, function () {
-					    if (index < $related.length - 1 || settings.loop) {
-					        timeOut = setTimeout(publicMethod.next, settings.slideshowSpeed);
-					    }
+						if (index < $related.length - 1 || settings.loop) {
+							timeOut = setTimeout(publicMethod.next, settings.slideshowSpeed);
+						}
 					})
 					.bind(event_load, function () {
-					    clearTimeout(timeOut);
+						clearTimeout(timeOut);
 					})
 					.one(click + ' ' + event_cleanup, stop);
-                $box.removeClass(className + "off").addClass(className + "on");
-                timeOut = setTimeout(publicMethod.next, settings.slideshowSpeed);
-            };
-
-            stop = function () {
-                clearTimeout(timeOut);
-                $slideshow
+				$box.removeClass(className + "off").addClass(className + "on");
+				timeOut = setTimeout(publicMethod.next, settings.slideshowSpeed);
+			};
+			
+			stop = function () {
+				clearTimeout(timeOut);
+				$slideshow
 					.text(settings.slideshowStart)
 					.unbind([event_complete, event_load, event_cleanup, click].join(' '))
 					.one(click, function () {
-					    publicMethod.next();
-					    start();
+						publicMethod.next();
+						start();
 					});
-                $box.removeClass(className + "on").addClass(className + "off");
-            };
-
-            if (settings.slideshowAuto) {
-                start();
-            } else {
-                stop();
-            }
-        } else {
+				$box.removeClass(className + "on").addClass(className + "off");
+			};
+			
+			if (settings.slideshowAuto) {
+				start();
+			} else {
+				stop();
+			}
+		} else {
             $box.removeClass(className + "off " + className + "on");
         }
-    }
+	}
 
-    function launch(target) {
-        if (!closing) {
+	function launch(target) {
+		if (!closing) {
+			
+			element = target;
+			
+			makeSettings();
+			
+			$related = $(element);
+			
+			index = 0;
+			
+			if (settings.rel !== 'nofollow') {
+				$related = $('.' + boxElement).filter(function () {
+					var relRelated = $.data(this, colorbox).rel || this.rel;
+					return (relRelated === settings.rel);
+				});
+				index = $related.index(element);
+				
+				// Check direct calls to ColorBox.
+				if (index === -1) {
+					$related = $related.add(element);
+					index = $related.length - 1;
+				}
+			}
+			
+			if (!open) {
+				open = active = true; // Prevents the page-change action from queuing up if the visitor holds down the left or right keys.
+				
+				$box.show();
+				
+				if (settings.returnFocus) {
+					try {
+						element.blur();
+						$(element).one(event_closed, function () {
+							try {
+								this.focus();
+							} catch (e) {
+								// do nothing
+							}
+						});
+					} catch (e) {
+						// do nothing
+					}
+				}
+				
+				// +settings.opacity avoids a problem in IE when using non-zero-prefixed-string-values, like '.5'
+				$overlay.css({"opacity": +settings.opacity, "cursor": settings.overlayClose ? "pointer" : "auto"}).show();
+				
+				// Opens inital empty ColorBox prior to content being loaded.
+				settings.w = setSize(settings.initialWidth, 'x');
+				settings.h = setSize(settings.initialHeight, 'y');
+				publicMethod.position();
+				
+				if (isIE6) {
+					$window.bind('resize.' + event_ie6 + ' scroll.' + event_ie6, function () {
+						$overlay.css({width: $window.width(), height: $window.height(), top: $window.scrollTop(), left: $window.scrollLeft()});
+					}).trigger('resize.' + event_ie6);
+				}
+				
+				trigger(event_open, settings.onOpen);
+				
+				$groupControls.add($title).hide();
+				
+				$close.html(settings.close).show();
+			}
+			
+			publicMethod.load(true);
+		}
+	}
 
-            element = target;
-
-            makeSettings();
-
-            $related = $(element);
-
-            index = 0;
-
-            if (settings.rel !== 'nofollow') {
-                $related = $('.' + boxElement).filter(function () {
-                    var relRelated = $.data(this, colorbox).rel || this.rel;
-                    return (relRelated === settings.rel);
-                });
-                index = $related.index(element);
-
-                // Check direct calls to ColorBox.
-                if (index === -1) {
-                    $related = $related.add(element);
-                    index = $related.length - 1;
-                }
-            }
-
-            if (!open) {
-                open = active = true; // Prevents the page-change action from queuing up if the visitor holds down the left or right keys.
-
-                $box.show();
-
-                if (settings.returnFocus) {
-                    try {
-                        element.blur();
-                        $(element).one(event_closed, function () {
-                            try {
-                                this.focus();
-                            } catch (e) {
-                                // do nothing
-                            }
-                        });
-                    } catch (e) {
-                        // do nothing
-                    }
-                }
-
-                // +settings.opacity avoids a problem in IE when using non-zero-prefixed-string-values, like '.5'
-                $overlay.css({ "opacity": +settings.opacity, "cursor": settings.overlayClose ? "pointer" : "auto" }).show();
-
-                // Opens inital empty ColorBox prior to content being loaded.
-                settings.w = setSize(settings.initialWidth, 'x');
-                settings.h = setSize(settings.initialHeight, 'y');
-                publicMethod.position();
-
-                if (isIE6) {
-                    $window.bind('resize.' + event_ie6 + ' scroll.' + event_ie6, function () {
-                        $overlay.css({ width: $window.width(), height: $window.height(), top: $window.scrollTop(), left: $window.scrollLeft() });
-                    }).trigger('resize.' + event_ie6);
-                }
-
-                trigger(event_open, settings.onOpen);
-
-                $groupControls.add($title).hide();
-
-                $close.html(settings.close).show();
-            }
-
-            publicMethod.load(true);
-        }
-    }
-
-    // ****************
-    // PUBLIC FUNCTIONS
-    // Usage format: $.fn.colorbox.close();
-    // Usage from within an iframe: parent.$.fn.colorbox.close();
-    // ****************
-
-    publicMethod = $.fn[colorbox] = $[colorbox] = function (options, callback) {
-        var $this = this;
-
+	// ****************
+	// PUBLIC FUNCTIONS
+	// Usage format: $.fn.colorbox.close();
+	// Usage from within an iframe: parent.$.fn.colorbox.close();
+	// ****************
+	
+	publicMethod = $.fn[colorbox] = $[colorbox] = function (options, callback) {
+		var $this = this;
+		
         options = options || {};
-
-        publicMethod.init();
-
-        if (!$this[0]) {
-            if ($this.selector) { // if a selector was given and it didn't match any elements, go ahead and exit.
+        
+		publicMethod.init();
+		
+		if (!$this[0]) {
+			if ($this.selector) { // if a selector was given and it didn't match any elements, go ahead and exit.
                 return $this;
             }
             // if no selector was given (ie. $.colorbox()), create a temporary element to work with
-            $this = $('<a/>');
-            options.open = true; // assume an immediate open
-        }
-
-        if (callback) {
-            options.onComplete = callback;
-        }
-
-        $this.each(function () {
-            $.data(this, colorbox, $.extend({}, $.data(this, colorbox) || defaults, options));
-            $(this).addClass(boxElement);
-        });
-
+			$this = $('<a/>');
+			options.open = true; // assume an immediate open
+		}
+		
+		if (callback) {
+			options.onComplete = callback;
+		}
+		
+		$this.each(function () {
+			$.data(this, colorbox, $.extend({}, $.data(this, colorbox) || defaults, options));
+			$(this).addClass(boxElement);
+		});
+		
         if (($.isFunction(options.open) && options.open.call($this)) || options.open) {
-            launch($this[0]);
-        }
+			launch($this[0]);
+		}
+        
+		return $this;
+	};
 
-        return $this;
-    };
-
-    // Initialize ColorBox: store common calculations, preload the interface graphics, append the html.
-    // This preps ColorBox for a speedy open when clicked, and minimizes the burdon on the browser by only
-    // having to run once, instead of each time colorbox is opened.
-    publicMethod.init = function () {
-        if (!$box) {
-
-            // If the body is not present yet, wait for DOM ready
-            if (!$('body')[0]) {
-                $(publicMethod.init);
-                return;
-            }
-
-            // Create the markup and append to BODY
-            $window = $(window);
-            $box = $tag(div).attr({ id: colorbox, 'class': isIE ? prefix + (isIE6 ? 'IE6' : 'IE') : '' });
-            $overlay = $tag(div, "Overlay", isIE6 ? 'position:absolute' : '').hide();
-            $wrap = $tag(div, "Wrapper");
-            $content = $tag(div, "Content").append(
+	// Initialize ColorBox: store common calculations, preload the interface graphics, append the html.
+	// This preps ColorBox for a speedy open when clicked, and minimizes the burdon on the browser by only
+	// having to run once, instead of each time colorbox is opened.
+	publicMethod.init = function () {
+		if (!$box) {
+			
+			// If the body is not present yet, wait for DOM ready
+			if (!$('body')[0]) {
+				$(publicMethod.init);
+				return;
+			}
+			
+			// Create the markup and append to BODY
+			$window = $(window);
+			$box = $tag(div).attr({id: colorbox, 'class': isIE ? prefix + (isIE6 ? 'IE6' : 'IE') : ''});
+			$overlay = $tag(div, "Overlay", isIE6 ? 'position:absolute' : '').hide();
+			$wrap = $tag(div, "Wrapper");
+			$content = $tag(div, "Content").append(
 				$loaded = $tag(div, "LoadedContent", 'width:0; height:0; overflow:hidden'),
 				$loadingOverlay = $tag(div, "LoadingOverlay").add($tag(div, "LoadingGraphic")),
 				$title = $tag(div, "Title"),
@@ -366,8 +366,8 @@
 				$slideshow = $tag(div, "Slideshow").bind(event_open, slideshow),
 				$close = $tag(div, "Close")
 			);
-
-            $wrap.append( // The 3x3 Grid that makes up ColorBox
+			
+			$wrap.append( // The 3x3 Grid that makes up ColorBox
 				$tag(div).append(
 					$tag(div, "TopLeft"),
 					$topBorder = $tag(div, "TopCenter"),
@@ -383,84 +383,84 @@
 					$bottomBorder = $tag(div, "BottomCenter"),
 					$tag(div, "BottomRight")
 				)
-			).find('div div').css({ 'float': 'left' });
+			).find('div div').css({'float': 'left'});
+			
+			$loadingBay = $tag(div, false, 'position:absolute; width:9999px; visibility:hidden; display:none');
+			
+			$('body').prepend($overlay, $box.append($wrap, $loadingBay));
+			
+			// Cache values needed for size calculations
+			interfaceHeight = $topBorder.height() + $bottomBorder.height() + $content.outerHeight(true) - $content.height();//Subtraction needed for IE6
+			interfaceWidth = $leftBorder.width() + $rightBorder.width() + $content.outerWidth(true) - $content.width();
+			loadedHeight = $loaded.outerHeight(true);
+			loadedWidth = $loaded.outerWidth(true);
+			
+			// Setting padding to remove the need to do size conversions during the animation step.
+			$box.css({"padding-bottom": interfaceHeight, "padding-right": interfaceWidth}).hide();
+			
+			// Setup button events.
+			// Anonymous functions here keep the public method from being cached, thereby allowing them to be redefined on the fly.
+			$next.click(function () {
+				publicMethod.next();
+			});
+			$prev.click(function () {
+				publicMethod.prev();
+			});
+			$close.click(function () {
+				publicMethod.close();
+			});
+			
+			$groupControls = $next.add($prev).add($current).add($slideshow);
+			
+			$overlay.click(function () {
+				if (settings.overlayClose) {
+					publicMethod.close();
+				}
+			});
+			
+			// Set Navigation Key Bindings
+			$(document).bind('keydown.' + prefix, function (e) {
+				var key = e.keyCode;
+				if (open && settings.escKey && key === 27) {
+					e.preventDefault();
+					publicMethod.close();
+				}
+				if (open && settings.arrowKey && $related[1]) {
+					if (key === 37) {
+						e.preventDefault();
+						$prev.click();
+					} else if (key === 39) {
+						e.preventDefault();
+						$next.click();
+					}
+				}
+			});
+		}
+	};
+	
+	publicMethod.remove = function () {
+		$box.add($overlay).remove();
+		$box = null;
+		$('.' + boxElement).removeData(colorbox).removeClass(boxElement);
+	};
 
-            $loadingBay = $tag(div, false, 'position:absolute; width:9999px; visibility:hidden; display:none');
-
-            $('body').prepend($overlay, $box.append($wrap, $loadingBay));
-
-            // Cache values needed for size calculations
-            interfaceHeight = $topBorder.height() + $bottomBorder.height() + $content.outerHeight(true) - $content.height(); //Subtraction needed for IE6
-            interfaceWidth = $leftBorder.width() + $rightBorder.width() + $content.outerWidth(true) - $content.width();
-            loadedHeight = $loaded.outerHeight(true);
-            loadedWidth = $loaded.outerWidth(true);
-
-            // Setting padding to remove the need to do size conversions during the animation step.
-            $box.css({ "padding-bottom": interfaceHeight, "padding-right": interfaceWidth }).hide();
-
-            // Setup button events.
-            // Anonymous functions here keep the public method from being cached, thereby allowing them to be redefined on the fly.
-            $next.click(function () {
-                publicMethod.next();
-            });
-            $prev.click(function () {
-                publicMethod.prev();
-            });
-            $close.click(function () {
-                publicMethod.close();
-            });
-
-            $groupControls = $next.add($prev).add($current).add($slideshow);
-
-            $overlay.click(function () {
-                if (settings.overlayClose) {
-                    publicMethod.close();
-                }
-            });
-
-            // Set Navigation Key Bindings
-            $(document).bind('keydown.' + prefix, function (e) {
-                var key = e.keyCode;
-                if (open && settings.escKey && key === 27) {
-                    e.preventDefault();
-                    publicMethod.close();
-                }
-                if (open && settings.arrowKey && $related[1]) {
-                    if (key === 37) {
-                        e.preventDefault();
-                        $prev.click();
-                    } else if (key === 39) {
-                        e.preventDefault();
-                        $next.click();
-                    }
-                }
-            });
-        }
-    };
-
-    publicMethod.remove = function () {
-        $box.add($overlay).remove();
-        $box = null;
-        $('.' + boxElement).removeData(colorbox).removeClass(boxElement);
-    };
-
-    publicMethod.position = function (speed, loadedCallback) {
+	publicMethod.position = function (speed, loadedCallback) {
         var top = 0, left = 0, offset = $box.offset();
-
+        
         $window.unbind('resize.' + prefix);
 
         // remove the modal so that it doesn't influence the document width/height        
-        $box.css({ top: -99999, left: -99999 });
+        $box.css({top: -99999, left: -99999});
 
         if (settings.fixed && !isIE6) {
-            $box.css({ position: 'fixed' });
+            $box.css({position: 'fixed'});
         } else {
             top = $window.scrollTop();
             left = $window.scrollLeft();
-            $box.css({ position: 'absolute' });
+            $box.css({position: 'absolute'});
         }
 
-        // keeps the top and left positions within the browser's viewport.
+		// keeps the top and left positions within the browser's viewport.
         if (settings.right !== false) {
             left += Math.max($window.width() - settings.w - loadedWidth - interfaceWidth - setSize(settings.right, 'x'), 0);
         } else if (settings.left !== false) {
@@ -468,7 +468,7 @@
         } else {
             left += Math.round(Math.max($window.width() - settings.w - loadedWidth - interfaceWidth, 0) / 2);
         }
-
+        
         if (settings.bottom !== false) {
             top += Math.max($window.height() - settings.h - loadedHeight - interfaceHeight - setSize(settings.bottom, 'y'), 0);
         } else if (settings.top !== false) {
@@ -476,183 +476,183 @@
         } else {
             top += Math.round(Math.max($window.height() - settings.h - loadedHeight - interfaceHeight, 0) / 2);
         }
-
-        $box.css({ top: offset.top, left: offset.left });
-
-        // setting the speed to 0 to reduce the delay between same-sized content.
-        speed = ($box.width() === settings.w + loadedWidth && $box.height() === settings.h + loadedHeight) ? 0 : speed || 0;
-
-        // this gives the wrapper plenty of breathing room so it's floated contents can move around smoothly,
-        // but it has to be shrank down around the size of div#colorbox when it's done.  If not,
-        // it can invoke an obscure IE bug when using iframes.
-        $wrap[0].style.width = $wrap[0].style.height = "9999px";
-
-        function modalDimensions(that) {
-            // loading overlay height has to be explicitly set for IE6.
-            $topBorder[0].style.width = $bottomBorder[0].style.width = $content[0].style.width = that.style.width;
-            $loadingOverlay[0].style.height = $loadingOverlay[1].style.height = $content[0].style.height = $leftBorder[0].style.height = $rightBorder[0].style.height = that.style.height;
-        }
-
-        $box.dequeue().animate({ width: settings.w + loadedWidth, height: settings.h + loadedHeight, top: top, left: left }, {
-            duration: speed,
-            complete: function () {
-                modalDimensions(this);
-
-                active = false;
-
-                // shrink the wrapper down to exactly the size of colorbox to avoid a bug in IE's iframe implementation.
-                $wrap[0].style.width = (settings.w + loadedWidth + interfaceWidth) + "px";
-                $wrap[0].style.height = (settings.h + loadedHeight + interfaceHeight) + "px";
-
-                if (loadedCallback) {
-                    loadedCallback();
-                }
-
+        
+        $box.css({top: offset.top, left: offset.left});
+        
+		// setting the speed to 0 to reduce the delay between same-sized content.
+		speed = ($box.width() === settings.w + loadedWidth && $box.height() === settings.h + loadedHeight) ? 0 : speed || 0;
+        
+		// this gives the wrapper plenty of breathing room so it's floated contents can move around smoothly,
+		// but it has to be shrank down around the size of div#colorbox when it's done.  If not,
+		// it can invoke an obscure IE bug when using iframes.
+		$wrap[0].style.width = $wrap[0].style.height = "9999px";
+		
+		function modalDimensions(that) {
+			// loading overlay height has to be explicitly set for IE6.
+			$topBorder[0].style.width = $bottomBorder[0].style.width = $content[0].style.width = that.style.width;
+			$loadingOverlay[0].style.height = $loadingOverlay[1].style.height = $content[0].style.height = $leftBorder[0].style.height = $rightBorder[0].style.height = that.style.height;
+		}
+		
+		$box.dequeue().animate({width: settings.w + loadedWidth, height: settings.h + loadedHeight, top: top, left: left}, {
+			duration: speed,
+			complete: function () {
+				modalDimensions(this);
+				
+				active = false;
+				
+				// shrink the wrapper down to exactly the size of colorbox to avoid a bug in IE's iframe implementation.
+				$wrap[0].style.width = (settings.w + loadedWidth + interfaceWidth) + "px";
+				$wrap[0].style.height = (settings.h + loadedHeight + interfaceHeight) + "px";
+				
+				if (loadedCallback) {
+					loadedCallback();
+				}
+                
                 setTimeout(function () {  // small delay before binding onresize due to an IE8 bug.
                     $window.bind('resize.' + prefix, publicMethod.position);
                 }, 1);
-            },
-            step: function () {
-                modalDimensions(this);
-            }
-        });
-    };
+			},
+			step: function () {
+				modalDimensions(this);
+			}
+		});
+	};
 
-    publicMethod.resize = function (options) {
-        if (open) {
-            options = options || {};
+	publicMethod.resize = function (options) {
+		if (open) {
+			options = options || {};
+			
+			if (options.width) {
+				settings.w = setSize(options.width, 'x') - loadedWidth - interfaceWidth;
+			}
+			if (options.innerWidth) {
+				settings.w = setSize(options.innerWidth, 'x');
+			}
+			$loaded.css({width: settings.w});
+			
+			if (options.height) {
+				settings.h = setSize(options.height, 'y') - loadedHeight - interfaceHeight;
+			}
+			if (options.innerHeight) {
+				settings.h = setSize(options.innerHeight, 'y');
+			}
+			if (!options.innerHeight && !options.height) {
+				$loaded.css({height: "auto"});
+				settings.h = $loaded.height();
+			}
+			$loaded.css({height: settings.h});
+			
+			publicMethod.position(settings.transition === "none" ? 0 : settings.speed);
+		}
+	};
 
-            if (options.width) {
-                settings.w = setSize(options.width, 'x') - loadedWidth - interfaceWidth;
-            }
-            if (options.innerWidth) {
-                settings.w = setSize(options.innerWidth, 'x');
-            }
-            $loaded.css({ width: settings.w });
-
-            if (options.height) {
-                settings.h = setSize(options.height, 'y') - loadedHeight - interfaceHeight;
-            }
-            if (options.innerHeight) {
-                settings.h = setSize(options.innerHeight, 'y');
-            }
-            if (!options.innerHeight && !options.height) {
-                $loaded.css({ height: "auto" });
-                settings.h = $loaded.height();
-            }
-            $loaded.css({ height: settings.h });
-
-            publicMethod.position(settings.transition === "none" ? 0 : settings.speed);
-        }
-    };
-
-    publicMethod.prep = function (object) {
-        if (!open) {
-            return;
-        }
-
-        var callback, speed = settings.transition === "none" ? 0 : settings.speed;
-
-        $loaded.remove();
-        $loaded = $tag(div, 'LoadedContent').append(object);
-
-        function getWidth() {
-            settings.w = settings.w || $loaded.width();
-            settings.w = settings.mw && settings.mw < settings.w ? settings.mw : settings.w;
-            return settings.w;
-        }
-        function getHeight() {
-            settings.h = settings.h || $loaded.height();
-            settings.h = settings.mh && settings.mh < settings.h ? settings.mh : settings.h;
-            return settings.h;
-        }
-
-        $loaded.hide()
+	publicMethod.prep = function (object) {
+		if (!open) {
+			return;
+		}
+		
+		var callback, speed = settings.transition === "none" ? 0 : settings.speed;
+		
+		$loaded.remove();
+		$loaded = $tag(div, 'LoadedContent').append(object);
+		
+		function getWidth() {
+			settings.w = settings.w || $loaded.width();
+			settings.w = settings.mw && settings.mw < settings.w ? settings.mw : settings.w;
+			return settings.w;
+		}
+		function getHeight() {
+			settings.h = settings.h || $loaded.height();
+			settings.h = settings.mh && settings.mh < settings.h ? settings.mh : settings.h;
+			return settings.h;
+		}
+		
+		$loaded.hide()
 		.appendTo($loadingBay.show())// content has to be appended to the DOM for accurate size calculations.
-		.css({ width: getWidth(), overflow: settings.scrolling ? 'auto' : 'hidden' })
-		.css({ height: getHeight() })// sets the height independently from the width in case the new width influences the value of height.
+		.css({width: getWidth(), overflow: settings.scrolling ? 'auto' : 'hidden'})
+		.css({height: getHeight()})// sets the height independently from the width in case the new width influences the value of height.
 		.prependTo($content);
-
-        $loadingBay.hide();
-
-        // floating the IMG removes the bottom line-height and fixed a problem where IE miscalculates the width of the parent element as 100% of the document width.
-        //$(photo).css({'float': 'none', marginLeft: 'auto', marginRight: 'auto'});
-
-        $(photo).css({ 'float': 'none' });
-
-        // Hides SELECT elements in IE6 because they would otherwise sit on top of the overlay.
-        if (isIE6) {
-            $('select').not($box.find('select')).filter(function () {
-                return this.style.visibility !== 'hidden';
-            }).css({ 'visibility': 'hidden' }).one(event_cleanup, function () {
-                this.style.visibility = 'inherit';
-            });
-        }
-
-        callback = function () {
+		
+		$loadingBay.hide();
+		
+		// floating the IMG removes the bottom line-height and fixed a problem where IE miscalculates the width of the parent element as 100% of the document width.
+		//$(photo).css({'float': 'none', marginLeft: 'auto', marginRight: 'auto'});
+		
+        $(photo).css({'float': 'none'});
+        
+		// Hides SELECT elements in IE6 because they would otherwise sit on top of the overlay.
+		if (isIE6) {
+			$('select').not($box.find('select')).filter(function () {
+				return this.style.visibility !== 'hidden';
+			}).css({'visibility': 'hidden'}).one(event_cleanup, function () {
+				this.style.visibility = 'inherit';
+			});
+		}
+		
+		callback = function () {
             var preload, i, total = $related.length, iframe, frameBorder = 'frameBorder', allowTransparency = 'allowTransparency', complete, src, img;
-
+            
             if (!open) {
                 return;
             }
-
+            
             function removeFilter() {
                 if (isIE) {
                     $box[0].style.removeAttribute('filter');
                 }
             }
-
+            
             complete = function () {
                 clearTimeout(loadingTimer);
                 $loadingOverlay.hide();
                 trigger(event_complete, settings.onComplete);
             };
-
+            
             if (isIE) {
                 //This fadeIn helps the bicubic resampling to kick-in.
                 if (photo) {
                     $loaded.fadeIn(100);
                 }
             }
-
+            
             $title.html(settings.title).add($loaded).show();
-
+            
             if (total > 1) { // handle grouping
                 if (typeof settings.current === "string") {
                     $current.html(settings.current.replace('{current}', index + 1).replace('{total}', total)).show();
                 }
-
+                
                 $next[(settings.loop || index < total - 1) ? "show" : "hide"]().html(settings.next);
                 $prev[(settings.loop || index) ? "show" : "hide"]().html(settings.previous);
-
+				
                 if (settings.slideshow) {
                     $slideshow.show();
                 }
-
+				
                 // Preloads images within a rel group
                 if (settings.preloading) {
-                    preload = [
+					preload = [
 						getIndex(-1),
 						getIndex(1)
 					];
-                    while ((i = $related[preload.pop()])) {
-                        src = $.data(i, colorbox).href || i.href;
-                        if ($.isFunction(src)) {
-                            src = src.call(i);
-                        }
-                        if (isImage(src)) {
-                            img = new Image();
-                            img.src = src;
-                        }
-                    }
+					while ((i = $related[preload.pop()])) {
+						src = $.data(i, colorbox).href || i.href;
+						if ($.isFunction(src)) {
+							src = src.call(i);
+						}
+						if (isImage(src)) {
+							img = new Image();
+							img.src = src;
+						}
+					}
                 }
             } else {
                 $groupControls.hide();
             }
-
+            
             if (settings.iframe) {
                 iframe = $tag('iframe')[0];
-
+                
                 if (frameBorder in iframe) {
                     iframe[frameBorder] = 0;
                 }
@@ -676,209 +676,210 @@
             } else {
                 complete();
             }
-
+            
             if (settings.transition === 'fade') {
                 $box.fadeTo(speed, 1, removeFilter);
             } else {
                 removeFilter();
             }
-        };
+		};
+		
+		if (settings.transition === 'fade') {
+			$box.fadeTo(speed, 0, function () {
+				publicMethod.position(0, callback);
+			});
+		} else {
+			publicMethod.position(speed, callback);
+		}
+	};
 
-        if (settings.transition === 'fade') {
-            $box.fadeTo(speed, 0, function () {
-                publicMethod.position(0, callback);
-            });
-        } else {
-            publicMethod.position(speed, callback);
-        }
-    };
-
-    publicMethod.load = function (launched) {
-        var href, setResize, prep = publicMethod.prep;
-
-        active = true;
-
-        photo = false;
-
-        element = $related[index];
-
-        if (!launched) {
-            makeSettings();
-        }
-
-        trigger(event_purge);
-
-        trigger(event_load, settings.onLoad);
-
-        settings.h = settings.height ?
+	publicMethod.load = function (launched) {
+		var href, setResize, prep = publicMethod.prep;
+		
+		active = true;
+		
+		photo = false;
+		
+		element = $related[index];
+		
+		if (!launched) {
+			makeSettings();
+		}
+		
+		trigger(event_purge);
+		
+		trigger(event_load, settings.onLoad);
+		
+		settings.h = settings.height ?
 				setSize(settings.height, 'y') - loadedHeight - interfaceHeight :
 				settings.innerHeight && setSize(settings.innerHeight, 'y');
-
-        settings.w = settings.width ?
+		
+		settings.w = settings.width ?
 				setSize(settings.width, 'x') - loadedWidth - interfaceWidth :
 				settings.innerWidth && setSize(settings.innerWidth, 'x');
-
-        // Sets the minimum dimensions for use in image scaling
-        settings.mw = settings.w;
-        settings.mh = settings.h;
-
-        // Re-evaluate the minimum width and height based on maxWidth and maxHeight values.
-        // If the width or height exceed the maxWidth or maxHeight, use the maximum values instead.
-        if (settings.maxWidth) {
-            settings.mw = setSize(settings.maxWidth, 'x') - loadedWidth - interfaceWidth;
-            settings.mw = settings.w && settings.w < settings.mw ? settings.w : settings.mw;
-        }
-        if (settings.maxHeight) {
-            settings.mh = setSize(settings.maxHeight, 'y') - loadedHeight - interfaceHeight;
-            settings.mh = settings.h && settings.h < settings.mh ? settings.h : settings.mh;
-        }
-
-        href = settings.href;
-
+		
+		// Sets the minimum dimensions for use in image scaling
+		settings.mw = settings.w;
+		settings.mh = settings.h;
+		
+		// Re-evaluate the minimum width and height based on maxWidth and maxHeight values.
+		// If the width or height exceed the maxWidth or maxHeight, use the maximum values instead.
+		if (settings.maxWidth) {
+			settings.mw = setSize(settings.maxWidth, 'x') - loadedWidth - interfaceWidth;
+			settings.mw = settings.w && settings.w < settings.mw ? settings.w : settings.mw;
+		}
+		if (settings.maxHeight) {
+			settings.mh = setSize(settings.maxHeight, 'y') - loadedHeight - interfaceHeight;
+			settings.mh = settings.h && settings.h < settings.mh ? settings.h : settings.mh;
+		}
+		
+		href = settings.href;
+		
         loadingTimer = setTimeout(function () {
             $loadingOverlay.show();
         }, 100);
-
-        if (settings.inline) {
-            // Inserts an empty placeholder where inline content is being pulled from.
-            // An event is bound to put inline content back when ColorBox closes or loads new content.
-            $tag(div).hide().insertBefore($(href)[0]).one(event_purge, function () {
-                $(this).replaceWith($loaded.children());
-            });
-            prep($(href));
-        } else if (settings.ajaxInline) {
-            var $target = $(settings.inlineTarget);
-
-            if ($target.children().length == 0) {
-                $loadingBay.load(href, settings.data, function (data, status, xhr) {
-                    $target.html(status === 'error' ? $tag(div, 'Error').text('Request unsuccessful: ' + xhr.statusText) : $(this).contents());
-                });
-            }
-
-            // Inserts an empty placeholder where inline content is being pulled from.
-            // An event is bound to put inline content back when ColorBox closes or loads new content.
-            $tag(div).hide().insertBefore($target[0]).one(event_purge, function () {
-                $(this).replaceWith($loaded.children());
-            });
-            prep($target);
-
-        } else if (settings.iframe) {
-            // IFrame element won't be added to the DOM until it is ready to be displayed,
-            // to avoid problems with DOM-ready JS that might be trying to run in that iframe.
-            prep(" ");
-        } else if (settings.html) {
-            prep(settings.html);
-        } else if (isImage(href)) {
-            $(photo = new Image())
+        
+		if (settings.inline) {
+			// Inserts an empty placeholder where inline content is being pulled from.
+			// An event is bound to put inline content back when ColorBox closes or loads new content.
+			$tag(div).hide().insertBefore($(href)[0]).one(event_purge, function () {
+				$(this).replaceWith($loaded.children());
+			});
+			prep($(href));
+		} else if (settings.ajaxInline) {
+			// Get inline target
+			var $target = $(settings.inlineTarget);
+			
+			// Only load once
+			if ($target.children().length == 0) {
+				$loadingBay.load(href, settings.data, function (data, status, xhr) {
+					$target.html(status === 'error' ? $tag(div, 'Error').text('Request unsuccessful: ' + xhr.statusText) : $(this).contents());
+				});
+			}
+			
+			// Inserts an empty placeholder where inline content is being pulled from.
+			// An event is bound to put inline content back when ColorBox closes or loads new content.
+			$tag(div).hide().insertBefore($target[0]).one(event_purge, function () {
+				$(this).replaceWith($loaded.children());
+			});
+			prep($target);
+		} else if (settings.iframe) {
+			// IFrame element won't be added to the DOM until it is ready to be displayed,
+			// to avoid problems with DOM-ready JS that might be trying to run in that iframe.
+			prep(" ");
+		} else if (settings.html) {
+			prep(settings.html);
+		} else if (isImage(href)) {
+			$(photo = new Image())
 			.addClass(prefix + 'Photo')
 			.error(function () {
-			    settings.title = false;
-			    prep($tag(div, 'Error').text('This image could not be loaded'));
+				settings.title = false;
+				prep($tag(div, 'Error').text('This image could not be loaded'));
 			})
 			.load(function () {
-			    var percent;
-			    photo.onload = null; //stops animated gifs from firing the onload repeatedly.
-
-			    if (settings.scalePhotos) {
-			        setResize = function () {
-			            photo.height -= photo.height * percent;
-			            photo.width -= photo.width * percent;
-			        };
-			        if (settings.mw && photo.width > settings.mw) {
-			            percent = (photo.width - settings.mw) / photo.width;
-			            setResize();
-			        }
-			        if (settings.mh && photo.height > settings.mh) {
-			            percent = (photo.height - settings.mh) / photo.height;
-			            setResize();
-			        }
-			    }
-
-			    if (settings.h) {
-			        photo.style.marginTop = Math.max(settings.h - photo.height, 0) / 2 + 'px';
-			    }
-
-			    if ($related[1] && (index < $related.length - 1 || settings.loop)) {
-			        photo.style.cursor = 'pointer';
-			        photo.onclick = function () {
-			            publicMethod.next();
-			        };
-			    }
-
-			    if (isIE) {
-			        photo.style.msInterpolationMode = 'bicubic';
-			    }
-
-			    setTimeout(function () { // A pause because Chrome will sometimes report a 0 by 0 size otherwise.
-			        prep(photo);
-			    }, 1);
+				var percent;
+				photo.onload = null; //stops animated gifs from firing the onload repeatedly.
+				
+				if (settings.scalePhotos) {
+					setResize = function () {
+						photo.height -= photo.height * percent;
+						photo.width -= photo.width * percent;	
+					};
+					if (settings.mw && photo.width > settings.mw) {
+						percent = (photo.width - settings.mw) / photo.width;
+						setResize();
+					}
+					if (settings.mh && photo.height > settings.mh) {
+						percent = (photo.height - settings.mh) / photo.height;
+						setResize();
+					}
+				}
+				
+				if (settings.h) {
+					photo.style.marginTop = Math.max(settings.h - photo.height, 0) / 2 + 'px';
+				}
+				
+				if ($related[1] && (index < $related.length - 1 || settings.loop)) {
+					photo.style.cursor = 'pointer';
+					photo.onclick = function () {
+                        publicMethod.next();
+                    };
+				}
+				
+				if (isIE) {
+					photo.style.msInterpolationMode = 'bicubic';
+				}
+				
+				setTimeout(function () { // A pause because Chrome will sometimes report a 0 by 0 size otherwise.
+					prep(photo);
+				}, 1);
 			});
+			
+			setTimeout(function () { // A pause because Opera 10.6+ will sometimes not run the onload function otherwise.
+				photo.src = href;
+			}, 1);
+		} else if (href) {
+			$loadingBay.load(href, settings.data, function (data, status, xhr) {
+				prep(status === 'error' ? $tag(div, 'Error').text('Request unsuccessful: ' + xhr.statusText) : $(this).contents());
+			});
+		}
+	};
+        
+	// Navigates to the next page/image in a set.
+	publicMethod.next = function () {
+		if (!active && $related[1] && (index < $related.length - 1 || settings.loop)) {
+			index = getIndex(1);
+			publicMethod.load();
+		}
+	};
+	
+	publicMethod.prev = function () {
+		if (!active && $related[1] && (index || settings.loop)) {
+			index = getIndex(-1);
+			publicMethod.load();
+		}
+	};
 
-            setTimeout(function () { // A pause because Opera 10.6+ will sometimes not run the onload function otherwise.
-                photo.src = href;
-            }, 1);
-        } else if (href) {
-            $loadingBay.load(href, settings.data, function (data, status, xhr) {
-                prep(status === 'error' ? $tag(div, 'Error').text('Request unsuccessful: ' + xhr.statusText) : $(this).contents());
-            });
-        }
-    };
+	// Note: to use this within an iframe use the following format: parent.$.fn.colorbox.close();
+	publicMethod.close = function () {
+		if (open && !closing) {
+			
+			closing = true;
+			
+			open = false;
+			
+			trigger(event_cleanup, settings.onCleanup);
+			
+			$window.unbind('.' + prefix + ' .' + event_ie6);
+			
+			$overlay.fadeTo(200, 0);
+			
+			$box.stop().fadeTo(300, 0, function () {
+                 
+				$box.add($overlay).css({'opacity': 1, cursor: 'auto'}).hide();
+				
+				trigger(event_purge);
+				
+				$loaded.remove();
+				
+				setTimeout(function () {
+					closing = false;
+					trigger(event_closed, settings.onClosed);
+				}, 1);
+			});
+		}
+	};
 
-    // Navigates to the next page/image in a set.
-    publicMethod.next = function () {
-        if (!active && $related[1] && (index < $related.length - 1 || settings.loop)) {
-            index = getIndex(1);
-            publicMethod.load();
-        }
-    };
+	// A method for fetching the current element ColorBox is referencing.
+	// returns a jQuery object.
+	publicMethod.element = function () {
+		return $(element);
+	};
 
-    publicMethod.prev = function () {
-        if (!active && $related[1] && (index || settings.loop)) {
-            index = getIndex(-1);
-            publicMethod.load();
-        }
-    };
-
-    // Note: to use this within an iframe use the following format: parent.$.fn.colorbox.close();
-    publicMethod.close = function () {
-        if (open && !closing) {
-
-            closing = true;
-
-            open = false;
-
-            trigger(event_cleanup, settings.onCleanup);
-
-            $window.unbind('.' + prefix + ' .' + event_ie6);
-
-            $overlay.fadeTo(200, 0);
-
-            $box.stop().fadeTo(300, 0, function () {
-
-                $box.add($overlay).css({ 'opacity': 1, cursor: 'auto' }).hide();
-
-                trigger(event_purge);
-
-                $loaded.remove();
-
-                setTimeout(function () {
-                    closing = false;
-                    trigger(event_closed, settings.onClosed);
-                }, 1);
-            });
-        }
-    };
-
-    // A method for fetching the current element ColorBox is referencing.
-    // returns a jQuery object.
-    publicMethod.element = function () {
-        return $(element);
-    };
-
-    publicMethod.settings = defaults;
-
-    // Bind the live event before DOM-ready for maximum performance in IE6 & 7.
-    $('.' + boxElement, document).live('click', function (e) {
+	publicMethod.settings = defaults;
+    
+	// Bind the live event before DOM-ready for maximum performance in IE6 & 7.
+	$('.' + boxElement, document).live('click', function (e) {
         // ignore non-left-mouse-clicks and clicks modified with ctrl / command, shift, or alt.
         // See: http://jacklmoore.com/notes/click-events/
         if (!(e.which > 1 || e.shiftKey || e.altKey || e.metaKey)) {
@@ -887,7 +888,7 @@
         }
     });
 
-    // Setup ColorBox
-    publicMethod.init();
+	// Setup ColorBox
+	publicMethod.init();
 
-} (jQuery, document, this));
+}(jQuery, document, this));

--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -3,7 +3,7 @@
 // Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
 
 (function ($, document, window) {
-    var
+    var 
     // Default settings object.	
     // See http://jacklmoore.com/colorbox for details.
     defaults = {
@@ -19,6 +19,7 @@
         maxHeight: false,
         scalePhotos: true,
         scrolling: true,
+        ajaxInline: false,
         inline: false,
         html: false,
         iframe: false,
@@ -46,7 +47,7 @@
         onComplete: false,
         onCleanup: false,
         onClosed: false,
-        overlayClose: true,		
+        overlayClose: true,
         escKey: true,
         arrowKey: true,
         top: false,
@@ -54,14 +55,15 @@
         left: false,
         right: false,
         fixed: false,
+        inlineTarget: undefined,
         data: undefined
     },
-	
+
     // Abstracting the HTML and event identifiers for easy rebranding
     colorbox = 'colorbox',
     prefix = 'cbox',
     boxElement = prefix + 'Element',
-    
+
     // Events	
     event_open = prefix + '_open',
     event_load = prefix + '_load',
@@ -69,12 +71,12 @@
     event_cleanup = prefix + '_cleanup',
     event_closed = prefix + '_closed',
     event_purge = prefix + '_purge',
-    
+
     // Special Handling for IE
     isIE = $.browser.msie && !$.support.opacity, // Detects IE6,7,8.  IE9 supports opacity.  Feature detection alone gave a false positive on at least one phone browser and on some development versions of Chrome, hence the user-agent test.
     isIE6 = isIE && $.browser.version < 7,
     event_ie6 = prefix + '_IE6',
-    
+
     // Cached jQuery Object Variables
     $overlay,
     $box,
@@ -96,7 +98,7 @@
     $prev,
     $close,
     $groupControls,
-    
+
     // Variables for cached values or use across multiple functions
     settings,
     interfaceHeight,
@@ -113,248 +115,248 @@
     publicMethod,
     div = "div";
 
-	// ****************
-	// HELPER FUNCTIONS
-	// ****************
-    
-	// Convience function for creating new jQuery objects
+    // ****************
+    // HELPER FUNCTIONS
+    // ****************
+
+    // Convience function for creating new jQuery objects
     function $tag(tag, id, css) {
         var element = document.createElement(tag);
-        
+
         if (id) {
             element.id = prefix + id;
         }
-        
+
         if (css) {
             element.style.cssText = css;
         }
-        
+
         return $(element);
     }
 
-	// Determine the next and previous members in a group.
-	function getIndex(increment) {
-		var 
-		max = $related.length, 
+    // Determine the next and previous members in a group.
+    function getIndex(increment) {
+        var 
+		max = $related.length,
 		newIndex = (index + increment) % max;
-		
-		return (newIndex < 0) ? max + newIndex : newIndex;
-	}
 
-	// Convert '%' and 'px' values to integers
-	function setSize(size, dimension) {
-		return Math.round((/%/.test(size) ? ((dimension === 'x' ? $window.width() : $window.height()) / 100) : 1) * parseInt(size, 10));
-	}
-	
-	// Checks an href to see if it is a photo.
-	// There is a force photo option (photo: true) for hrefs that cannot be matched by this regex.
-	function isImage(url) {
-		return settings.photo || /\.(gif|png|jpe?g|bmp|ico)((#|\?).*)?$/i.test(url);
-	}
-	
-	// Assigns function results to their respective properties
-	function makeSettings() {
+        return (newIndex < 0) ? max + newIndex : newIndex;
+    }
+
+    // Convert '%' and 'px' values to integers
+    function setSize(size, dimension) {
+        return Math.round((/%/.test(size) ? ((dimension === 'x' ? $window.width() : $window.height()) / 100) : 1) * parseInt(size, 10));
+    }
+
+    // Checks an href to see if it is a photo.
+    // There is a force photo option (photo: true) for hrefs that cannot be matched by this regex.
+    function isImage(url) {
+        return settings.photo || /\.(gif|png|jpe?g|bmp|ico)((#|\?).*)?$/i.test(url);
+    }
+
+    // Assigns function results to their respective properties
+    function makeSettings() {
         var i;
         settings = $.extend({}, $.data(element, colorbox));
-        
-		for (i in settings) {
-			if ($.isFunction(settings[i]) && i.slice(0, 2) !== 'on') { // checks to make sure the function isn't one of the callbacks, they will be handled at the appropriate time.
-			    settings[i] = settings[i].call(element);
-			}
-		}
-        
-		settings.rel = settings.rel || element.rel || 'nofollow';
-		settings.href = settings.href || $(element).attr('href');
-		settings.title = settings.title || element.title;
-        
+
+        for (i in settings) {
+            if ($.isFunction(settings[i]) && i.slice(0, 2) !== 'on') { // checks to make sure the function isn't one of the callbacks, they will be handled at the appropriate time.
+                settings[i] = settings[i].call(element);
+            }
+        }
+
+        settings.rel = settings.rel || element.rel || 'nofollow';
+        settings.href = settings.href || $(element).attr('href');
+        settings.title = settings.title || element.title;
+
         if (typeof settings.href === "string") {
             settings.href = $.trim(settings.href);
         }
-	}
+    }
 
-	function trigger(event, callback) {
-		$.event.trigger(event);
-		if (callback) {
-			callback.call(element);
-		}
-	}
+    function trigger(event, callback) {
+        $.event.trigger(event);
+        if (callback) {
+            callback.call(element);
+        }
+    }
 
-	// Slideshow functionality
-	function slideshow() {
-		var
+    // Slideshow functionality
+    function slideshow() {
+        var 
 		timeOut,
 		className = prefix + "Slideshow_",
 		click = "click." + prefix,
 		start,
 		stop,
 		clear;
-		
-		if (settings.slideshow && $related[1]) {
-			start = function () {
-				$slideshow
+
+        if (settings.slideshow && $related[1]) {
+            start = function () {
+                $slideshow
 					.text(settings.slideshowStop)
 					.unbind(click)
 					.bind(event_complete, function () {
-						if (index < $related.length - 1 || settings.loop) {
-							timeOut = setTimeout(publicMethod.next, settings.slideshowSpeed);
-						}
+					    if (index < $related.length - 1 || settings.loop) {
+					        timeOut = setTimeout(publicMethod.next, settings.slideshowSpeed);
+					    }
 					})
 					.bind(event_load, function () {
-						clearTimeout(timeOut);
+					    clearTimeout(timeOut);
 					})
 					.one(click + ' ' + event_cleanup, stop);
-				$box.removeClass(className + "off").addClass(className + "on");
-				timeOut = setTimeout(publicMethod.next, settings.slideshowSpeed);
-			};
-			
-			stop = function () {
-				clearTimeout(timeOut);
-				$slideshow
+                $box.removeClass(className + "off").addClass(className + "on");
+                timeOut = setTimeout(publicMethod.next, settings.slideshowSpeed);
+            };
+
+            stop = function () {
+                clearTimeout(timeOut);
+                $slideshow
 					.text(settings.slideshowStart)
 					.unbind([event_complete, event_load, event_cleanup, click].join(' '))
 					.one(click, function () {
-						publicMethod.next();
-						start();
+					    publicMethod.next();
+					    start();
 					});
-				$box.removeClass(className + "on").addClass(className + "off");
-			};
-			
-			if (settings.slideshowAuto) {
-				start();
-			} else {
-				stop();
-			}
-		} else {
+                $box.removeClass(className + "on").addClass(className + "off");
+            };
+
+            if (settings.slideshowAuto) {
+                start();
+            } else {
+                stop();
+            }
+        } else {
             $box.removeClass(className + "off " + className + "on");
         }
-	}
+    }
 
-	function launch(target) {
-		if (!closing) {
-			
-			element = target;
-			
-			makeSettings();
-			
-			$related = $(element);
-			
-			index = 0;
-			
-			if (settings.rel !== 'nofollow') {
-				$related = $('.' + boxElement).filter(function () {
-					var relRelated = $.data(this, colorbox).rel || this.rel;
-					return (relRelated === settings.rel);
-				});
-				index = $related.index(element);
-				
-				// Check direct calls to ColorBox.
-				if (index === -1) {
-					$related = $related.add(element);
-					index = $related.length - 1;
-				}
-			}
-			
-			if (!open) {
-				open = active = true; // Prevents the page-change action from queuing up if the visitor holds down the left or right keys.
-				
-				$box.show();
-				
-				if (settings.returnFocus) {
-					try {
-						element.blur();
-						$(element).one(event_closed, function () {
-							try {
-								this.focus();
-							} catch (e) {
-								// do nothing
-							}
-						});
-					} catch (e) {
-						// do nothing
-					}
-				}
-				
-				// +settings.opacity avoids a problem in IE when using non-zero-prefixed-string-values, like '.5'
-				$overlay.css({"opacity": +settings.opacity, "cursor": settings.overlayClose ? "pointer" : "auto"}).show();
-				
-				// Opens inital empty ColorBox prior to content being loaded.
-				settings.w = setSize(settings.initialWidth, 'x');
-				settings.h = setSize(settings.initialHeight, 'y');
-				publicMethod.position();
-				
-				if (isIE6) {
-					$window.bind('resize.' + event_ie6 + ' scroll.' + event_ie6, function () {
-						$overlay.css({width: $window.width(), height: $window.height(), top: $window.scrollTop(), left: $window.scrollLeft()});
-					}).trigger('resize.' + event_ie6);
-				}
-				
-				trigger(event_open, settings.onOpen);
-				
-				$groupControls.add($title).hide();
-				
-				$close.html(settings.close).show();
-			}
-			
-			publicMethod.load(true);
-		}
-	}
+    function launch(target) {
+        if (!closing) {
 
-	// ****************
-	// PUBLIC FUNCTIONS
-	// Usage format: $.fn.colorbox.close();
-	// Usage from within an iframe: parent.$.fn.colorbox.close();
-	// ****************
-	
-	publicMethod = $.fn[colorbox] = $[colorbox] = function (options, callback) {
-		var $this = this;
-		
+            element = target;
+
+            makeSettings();
+
+            $related = $(element);
+
+            index = 0;
+
+            if (settings.rel !== 'nofollow') {
+                $related = $('.' + boxElement).filter(function () {
+                    var relRelated = $.data(this, colorbox).rel || this.rel;
+                    return (relRelated === settings.rel);
+                });
+                index = $related.index(element);
+
+                // Check direct calls to ColorBox.
+                if (index === -1) {
+                    $related = $related.add(element);
+                    index = $related.length - 1;
+                }
+            }
+
+            if (!open) {
+                open = active = true; // Prevents the page-change action from queuing up if the visitor holds down the left or right keys.
+
+                $box.show();
+
+                if (settings.returnFocus) {
+                    try {
+                        element.blur();
+                        $(element).one(event_closed, function () {
+                            try {
+                                this.focus();
+                            } catch (e) {
+                                // do nothing
+                            }
+                        });
+                    } catch (e) {
+                        // do nothing
+                    }
+                }
+
+                // +settings.opacity avoids a problem in IE when using non-zero-prefixed-string-values, like '.5'
+                $overlay.css({ "opacity": +settings.opacity, "cursor": settings.overlayClose ? "pointer" : "auto" }).show();
+
+                // Opens inital empty ColorBox prior to content being loaded.
+                settings.w = setSize(settings.initialWidth, 'x');
+                settings.h = setSize(settings.initialHeight, 'y');
+                publicMethod.position();
+
+                if (isIE6) {
+                    $window.bind('resize.' + event_ie6 + ' scroll.' + event_ie6, function () {
+                        $overlay.css({ width: $window.width(), height: $window.height(), top: $window.scrollTop(), left: $window.scrollLeft() });
+                    }).trigger('resize.' + event_ie6);
+                }
+
+                trigger(event_open, settings.onOpen);
+
+                $groupControls.add($title).hide();
+
+                $close.html(settings.close).show();
+            }
+
+            publicMethod.load(true);
+        }
+    }
+
+    // ****************
+    // PUBLIC FUNCTIONS
+    // Usage format: $.fn.colorbox.close();
+    // Usage from within an iframe: parent.$.fn.colorbox.close();
+    // ****************
+
+    publicMethod = $.fn[colorbox] = $[colorbox] = function (options, callback) {
+        var $this = this;
+
         options = options || {};
-        
-		publicMethod.init();
-		
-		if (!$this[0]) {
-			if ($this.selector) { // if a selector was given and it didn't match any elements, go ahead and exit.
+
+        publicMethod.init();
+
+        if (!$this[0]) {
+            if ($this.selector) { // if a selector was given and it didn't match any elements, go ahead and exit.
                 return $this;
             }
             // if no selector was given (ie. $.colorbox()), create a temporary element to work with
-			$this = $('<a/>');
-			options.open = true; // assume an immediate open
-		}
-		
-		if (callback) {
-			options.onComplete = callback;
-		}
-		
-		$this.each(function () {
-			$.data(this, colorbox, $.extend({}, $.data(this, colorbox) || defaults, options));
-			$(this).addClass(boxElement);
-		});
-		
-        if (($.isFunction(options.open) && options.open.call($this)) || options.open) {
-			launch($this[0]);
-		}
-        
-		return $this;
-	};
+            $this = $('<a/>');
+            options.open = true; // assume an immediate open
+        }
 
-	// Initialize ColorBox: store common calculations, preload the interface graphics, append the html.
-	// This preps ColorBox for a speedy open when clicked, and minimizes the burdon on the browser by only
-	// having to run once, instead of each time colorbox is opened.
-	publicMethod.init = function () {
-		if (!$box) {
-			
-			// If the body is not present yet, wait for DOM ready
-			if (!$('body')[0]) {
-				$(publicMethod.init);
-				return;
-			}
-			
-			// Create the markup and append to BODY
-			$window = $(window);
-			$box = $tag(div).attr({id: colorbox, 'class': isIE ? prefix + (isIE6 ? 'IE6' : 'IE') : ''});
-			$overlay = $tag(div, "Overlay", isIE6 ? 'position:absolute' : '').hide();
-			$wrap = $tag(div, "Wrapper");
-			$content = $tag(div, "Content").append(
+        if (callback) {
+            options.onComplete = callback;
+        }
+
+        $this.each(function () {
+            $.data(this, colorbox, $.extend({}, $.data(this, colorbox) || defaults, options));
+            $(this).addClass(boxElement);
+        });
+
+        if (($.isFunction(options.open) && options.open.call($this)) || options.open) {
+            launch($this[0]);
+        }
+
+        return $this;
+    };
+
+    // Initialize ColorBox: store common calculations, preload the interface graphics, append the html.
+    // This preps ColorBox for a speedy open when clicked, and minimizes the burdon on the browser by only
+    // having to run once, instead of each time colorbox is opened.
+    publicMethod.init = function () {
+        if (!$box) {
+
+            // If the body is not present yet, wait for DOM ready
+            if (!$('body')[0]) {
+                $(publicMethod.init);
+                return;
+            }
+
+            // Create the markup and append to BODY
+            $window = $(window);
+            $box = $tag(div).attr({ id: colorbox, 'class': isIE ? prefix + (isIE6 ? 'IE6' : 'IE') : '' });
+            $overlay = $tag(div, "Overlay", isIE6 ? 'position:absolute' : '').hide();
+            $wrap = $tag(div, "Wrapper");
+            $content = $tag(div, "Content").append(
 				$loaded = $tag(div, "LoadedContent", 'width:0; height:0; overflow:hidden'),
 				$loadingOverlay = $tag(div, "LoadingOverlay").add($tag(div, "LoadingGraphic")),
 				$title = $tag(div, "Title"),
@@ -364,8 +366,8 @@
 				$slideshow = $tag(div, "Slideshow").bind(event_open, slideshow),
 				$close = $tag(div, "Close")
 			);
-			
-			$wrap.append( // The 3x3 Grid that makes up ColorBox
+
+            $wrap.append( // The 3x3 Grid that makes up ColorBox
 				$tag(div).append(
 					$tag(div, "TopLeft"),
 					$topBorder = $tag(div, "TopCenter"),
@@ -381,84 +383,84 @@
 					$bottomBorder = $tag(div, "BottomCenter"),
 					$tag(div, "BottomRight")
 				)
-			).find('div div').css({'float': 'left'});
-			
-			$loadingBay = $tag(div, false, 'position:absolute; width:9999px; visibility:hidden; display:none');
-			
-			$('body').prepend($overlay, $box.append($wrap, $loadingBay));
-			
-			// Cache values needed for size calculations
-			interfaceHeight = $topBorder.height() + $bottomBorder.height() + $content.outerHeight(true) - $content.height();//Subtraction needed for IE6
-			interfaceWidth = $leftBorder.width() + $rightBorder.width() + $content.outerWidth(true) - $content.width();
-			loadedHeight = $loaded.outerHeight(true);
-			loadedWidth = $loaded.outerWidth(true);
-			
-			// Setting padding to remove the need to do size conversions during the animation step.
-			$box.css({"padding-bottom": interfaceHeight, "padding-right": interfaceWidth}).hide();
-			
-			// Setup button events.
-			// Anonymous functions here keep the public method from being cached, thereby allowing them to be redefined on the fly.
-			$next.click(function () {
-				publicMethod.next();
-			});
-			$prev.click(function () {
-				publicMethod.prev();
-			});
-			$close.click(function () {
-				publicMethod.close();
-			});
-			
-			$groupControls = $next.add($prev).add($current).add($slideshow);
-			
-			$overlay.click(function () {
-				if (settings.overlayClose) {
-					publicMethod.close();
-				}
-			});
-			
-			// Set Navigation Key Bindings
-			$(document).bind('keydown.' + prefix, function (e) {
-				var key = e.keyCode;
-				if (open && settings.escKey && key === 27) {
-					e.preventDefault();
-					publicMethod.close();
-				}
-				if (open && settings.arrowKey && $related[1]) {
-					if (key === 37) {
-						e.preventDefault();
-						$prev.click();
-					} else if (key === 39) {
-						e.preventDefault();
-						$next.click();
-					}
-				}
-			});
-		}
-	};
-	
-	publicMethod.remove = function () {
-		$box.add($overlay).remove();
-		$box = null;
-		$('.' + boxElement).removeData(colorbox).removeClass(boxElement);
-	};
+			).find('div div').css({ 'float': 'left' });
 
-	publicMethod.position = function (speed, loadedCallback) {
+            $loadingBay = $tag(div, false, 'position:absolute; width:9999px; visibility:hidden; display:none');
+
+            $('body').prepend($overlay, $box.append($wrap, $loadingBay));
+
+            // Cache values needed for size calculations
+            interfaceHeight = $topBorder.height() + $bottomBorder.height() + $content.outerHeight(true) - $content.height(); //Subtraction needed for IE6
+            interfaceWidth = $leftBorder.width() + $rightBorder.width() + $content.outerWidth(true) - $content.width();
+            loadedHeight = $loaded.outerHeight(true);
+            loadedWidth = $loaded.outerWidth(true);
+
+            // Setting padding to remove the need to do size conversions during the animation step.
+            $box.css({ "padding-bottom": interfaceHeight, "padding-right": interfaceWidth }).hide();
+
+            // Setup button events.
+            // Anonymous functions here keep the public method from being cached, thereby allowing them to be redefined on the fly.
+            $next.click(function () {
+                publicMethod.next();
+            });
+            $prev.click(function () {
+                publicMethod.prev();
+            });
+            $close.click(function () {
+                publicMethod.close();
+            });
+
+            $groupControls = $next.add($prev).add($current).add($slideshow);
+
+            $overlay.click(function () {
+                if (settings.overlayClose) {
+                    publicMethod.close();
+                }
+            });
+
+            // Set Navigation Key Bindings
+            $(document).bind('keydown.' + prefix, function (e) {
+                var key = e.keyCode;
+                if (open && settings.escKey && key === 27) {
+                    e.preventDefault();
+                    publicMethod.close();
+                }
+                if (open && settings.arrowKey && $related[1]) {
+                    if (key === 37) {
+                        e.preventDefault();
+                        $prev.click();
+                    } else if (key === 39) {
+                        e.preventDefault();
+                        $next.click();
+                    }
+                }
+            });
+        }
+    };
+
+    publicMethod.remove = function () {
+        $box.add($overlay).remove();
+        $box = null;
+        $('.' + boxElement).removeData(colorbox).removeClass(boxElement);
+    };
+
+    publicMethod.position = function (speed, loadedCallback) {
         var top = 0, left = 0, offset = $box.offset();
-        
+
         $window.unbind('resize.' + prefix);
 
         // remove the modal so that it doesn't influence the document width/height        
-        $box.css({top: -99999, left: -99999});
+        $box.css({ top: -99999, left: -99999 });
 
         if (settings.fixed && !isIE6) {
-            $box.css({position: 'fixed'});
+            $box.css({ position: 'fixed' });
         } else {
             top = $window.scrollTop();
             left = $window.scrollLeft();
-            $box.css({position: 'absolute'});
+            $box.css({ position: 'absolute' });
         }
 
-		// keeps the top and left positions within the browser's viewport.
+        // keeps the top and left positions within the browser's viewport.
         if (settings.right !== false) {
             left += Math.max($window.width() - settings.w - loadedWidth - interfaceWidth - setSize(settings.right, 'x'), 0);
         } else if (settings.left !== false) {
@@ -466,7 +468,7 @@
         } else {
             left += Math.round(Math.max($window.width() - settings.w - loadedWidth - interfaceWidth, 0) / 2);
         }
-        
+
         if (settings.bottom !== false) {
             top += Math.max($window.height() - settings.h - loadedHeight - interfaceHeight - setSize(settings.bottom, 'y'), 0);
         } else if (settings.top !== false) {
@@ -474,183 +476,183 @@
         } else {
             top += Math.round(Math.max($window.height() - settings.h - loadedHeight - interfaceHeight, 0) / 2);
         }
-        
-        $box.css({top: offset.top, left: offset.left});
-        
-		// setting the speed to 0 to reduce the delay between same-sized content.
-		speed = ($box.width() === settings.w + loadedWidth && $box.height() === settings.h + loadedHeight) ? 0 : speed || 0;
-        
-		// this gives the wrapper plenty of breathing room so it's floated contents can move around smoothly,
-		// but it has to be shrank down around the size of div#colorbox when it's done.  If not,
-		// it can invoke an obscure IE bug when using iframes.
-		$wrap[0].style.width = $wrap[0].style.height = "9999px";
-		
-		function modalDimensions(that) {
-			// loading overlay height has to be explicitly set for IE6.
-			$topBorder[0].style.width = $bottomBorder[0].style.width = $content[0].style.width = that.style.width;
-			$loadingOverlay[0].style.height = $loadingOverlay[1].style.height = $content[0].style.height = $leftBorder[0].style.height = $rightBorder[0].style.height = that.style.height;
-		}
-		
-		$box.dequeue().animate({width: settings.w + loadedWidth, height: settings.h + loadedHeight, top: top, left: left}, {
-			duration: speed,
-			complete: function () {
-				modalDimensions(this);
-				
-				active = false;
-				
-				// shrink the wrapper down to exactly the size of colorbox to avoid a bug in IE's iframe implementation.
-				$wrap[0].style.width = (settings.w + loadedWidth + interfaceWidth) + "px";
-				$wrap[0].style.height = (settings.h + loadedHeight + interfaceHeight) + "px";
-				
-				if (loadedCallback) {
-					loadedCallback();
-				}
-                
+
+        $box.css({ top: offset.top, left: offset.left });
+
+        // setting the speed to 0 to reduce the delay between same-sized content.
+        speed = ($box.width() === settings.w + loadedWidth && $box.height() === settings.h + loadedHeight) ? 0 : speed || 0;
+
+        // this gives the wrapper plenty of breathing room so it's floated contents can move around smoothly,
+        // but it has to be shrank down around the size of div#colorbox when it's done.  If not,
+        // it can invoke an obscure IE bug when using iframes.
+        $wrap[0].style.width = $wrap[0].style.height = "9999px";
+
+        function modalDimensions(that) {
+            // loading overlay height has to be explicitly set for IE6.
+            $topBorder[0].style.width = $bottomBorder[0].style.width = $content[0].style.width = that.style.width;
+            $loadingOverlay[0].style.height = $loadingOverlay[1].style.height = $content[0].style.height = $leftBorder[0].style.height = $rightBorder[0].style.height = that.style.height;
+        }
+
+        $box.dequeue().animate({ width: settings.w + loadedWidth, height: settings.h + loadedHeight, top: top, left: left }, {
+            duration: speed,
+            complete: function () {
+                modalDimensions(this);
+
+                active = false;
+
+                // shrink the wrapper down to exactly the size of colorbox to avoid a bug in IE's iframe implementation.
+                $wrap[0].style.width = (settings.w + loadedWidth + interfaceWidth) + "px";
+                $wrap[0].style.height = (settings.h + loadedHeight + interfaceHeight) + "px";
+
+                if (loadedCallback) {
+                    loadedCallback();
+                }
+
                 setTimeout(function () {  // small delay before binding onresize due to an IE8 bug.
                     $window.bind('resize.' + prefix, publicMethod.position);
                 }, 1);
-			},
-			step: function () {
-				modalDimensions(this);
-			}
-		});
-	};
+            },
+            step: function () {
+                modalDimensions(this);
+            }
+        });
+    };
 
-	publicMethod.resize = function (options) {
-		if (open) {
-			options = options || {};
-			
-			if (options.width) {
-				settings.w = setSize(options.width, 'x') - loadedWidth - interfaceWidth;
-			}
-			if (options.innerWidth) {
-				settings.w = setSize(options.innerWidth, 'x');
-			}
-			$loaded.css({width: settings.w});
-			
-			if (options.height) {
-				settings.h = setSize(options.height, 'y') - loadedHeight - interfaceHeight;
-			}
-			if (options.innerHeight) {
-				settings.h = setSize(options.innerHeight, 'y');
-			}
-			if (!options.innerHeight && !options.height) {
-				$loaded.css({height: "auto"});
-				settings.h = $loaded.height();
-			}
-			$loaded.css({height: settings.h});
-			
-			publicMethod.position(settings.transition === "none" ? 0 : settings.speed);
-		}
-	};
+    publicMethod.resize = function (options) {
+        if (open) {
+            options = options || {};
 
-	publicMethod.prep = function (object) {
-		if (!open) {
-			return;
-		}
-		
-		var callback, speed = settings.transition === "none" ? 0 : settings.speed;
-		
-		$loaded.remove();
-		$loaded = $tag(div, 'LoadedContent').append(object);
-		
-		function getWidth() {
-			settings.w = settings.w || $loaded.width();
-			settings.w = settings.mw && settings.mw < settings.w ? settings.mw : settings.w;
-			return settings.w;
-		}
-		function getHeight() {
-			settings.h = settings.h || $loaded.height();
-			settings.h = settings.mh && settings.mh < settings.h ? settings.mh : settings.h;
-			return settings.h;
-		}
-		
-		$loaded.hide()
+            if (options.width) {
+                settings.w = setSize(options.width, 'x') - loadedWidth - interfaceWidth;
+            }
+            if (options.innerWidth) {
+                settings.w = setSize(options.innerWidth, 'x');
+            }
+            $loaded.css({ width: settings.w });
+
+            if (options.height) {
+                settings.h = setSize(options.height, 'y') - loadedHeight - interfaceHeight;
+            }
+            if (options.innerHeight) {
+                settings.h = setSize(options.innerHeight, 'y');
+            }
+            if (!options.innerHeight && !options.height) {
+                $loaded.css({ height: "auto" });
+                settings.h = $loaded.height();
+            }
+            $loaded.css({ height: settings.h });
+
+            publicMethod.position(settings.transition === "none" ? 0 : settings.speed);
+        }
+    };
+
+    publicMethod.prep = function (object) {
+        if (!open) {
+            return;
+        }
+
+        var callback, speed = settings.transition === "none" ? 0 : settings.speed;
+
+        $loaded.remove();
+        $loaded = $tag(div, 'LoadedContent').append(object);
+
+        function getWidth() {
+            settings.w = settings.w || $loaded.width();
+            settings.w = settings.mw && settings.mw < settings.w ? settings.mw : settings.w;
+            return settings.w;
+        }
+        function getHeight() {
+            settings.h = settings.h || $loaded.height();
+            settings.h = settings.mh && settings.mh < settings.h ? settings.mh : settings.h;
+            return settings.h;
+        }
+
+        $loaded.hide()
 		.appendTo($loadingBay.show())// content has to be appended to the DOM for accurate size calculations.
-		.css({width: getWidth(), overflow: settings.scrolling ? 'auto' : 'hidden'})
-		.css({height: getHeight()})// sets the height independently from the width in case the new width influences the value of height.
+		.css({ width: getWidth(), overflow: settings.scrolling ? 'auto' : 'hidden' })
+		.css({ height: getHeight() })// sets the height independently from the width in case the new width influences the value of height.
 		.prependTo($content);
-		
-		$loadingBay.hide();
-		
-		// floating the IMG removes the bottom line-height and fixed a problem where IE miscalculates the width of the parent element as 100% of the document width.
-		//$(photo).css({'float': 'none', marginLeft: 'auto', marginRight: 'auto'});
-		
-        $(photo).css({'float': 'none'});
-        
-		// Hides SELECT elements in IE6 because they would otherwise sit on top of the overlay.
-		if (isIE6) {
-			$('select').not($box.find('select')).filter(function () {
-				return this.style.visibility !== 'hidden';
-			}).css({'visibility': 'hidden'}).one(event_cleanup, function () {
-				this.style.visibility = 'inherit';
-			});
-		}
-		
-		callback = function () {
+
+        $loadingBay.hide();
+
+        // floating the IMG removes the bottom line-height and fixed a problem where IE miscalculates the width of the parent element as 100% of the document width.
+        //$(photo).css({'float': 'none', marginLeft: 'auto', marginRight: 'auto'});
+
+        $(photo).css({ 'float': 'none' });
+
+        // Hides SELECT elements in IE6 because they would otherwise sit on top of the overlay.
+        if (isIE6) {
+            $('select').not($box.find('select')).filter(function () {
+                return this.style.visibility !== 'hidden';
+            }).css({ 'visibility': 'hidden' }).one(event_cleanup, function () {
+                this.style.visibility = 'inherit';
+            });
+        }
+
+        callback = function () {
             var preload, i, total = $related.length, iframe, frameBorder = 'frameBorder', allowTransparency = 'allowTransparency', complete, src, img;
-            
+
             if (!open) {
                 return;
             }
-            
+
             function removeFilter() {
                 if (isIE) {
                     $box[0].style.removeAttribute('filter');
                 }
             }
-            
+
             complete = function () {
                 clearTimeout(loadingTimer);
                 $loadingOverlay.hide();
                 trigger(event_complete, settings.onComplete);
             };
-            
+
             if (isIE) {
                 //This fadeIn helps the bicubic resampling to kick-in.
                 if (photo) {
                     $loaded.fadeIn(100);
                 }
             }
-            
+
             $title.html(settings.title).add($loaded).show();
-            
+
             if (total > 1) { // handle grouping
                 if (typeof settings.current === "string") {
                     $current.html(settings.current.replace('{current}', index + 1).replace('{total}', total)).show();
                 }
-                
+
                 $next[(settings.loop || index < total - 1) ? "show" : "hide"]().html(settings.next);
                 $prev[(settings.loop || index) ? "show" : "hide"]().html(settings.previous);
-				
+
                 if (settings.slideshow) {
                     $slideshow.show();
                 }
-				
+
                 // Preloads images within a rel group
                 if (settings.preloading) {
-					preload = [
+                    preload = [
 						getIndex(-1),
 						getIndex(1)
 					];
-					while ((i = $related[preload.pop()])) {
-						src = $.data(i, colorbox).href || i.href;
-						if ($.isFunction(src)) {
-							src = src.call(i);
-						}
-						if (isImage(src)) {
-							img = new Image();
-							img.src = src;
-						}
-					}
+                    while ((i = $related[preload.pop()])) {
+                        src = $.data(i, colorbox).href || i.href;
+                        if ($.isFunction(src)) {
+                            src = src.call(i);
+                        }
+                        if (isImage(src)) {
+                            img = new Image();
+                            img.src = src;
+                        }
+                    }
                 }
             } else {
                 $groupControls.hide();
             }
-            
+
             if (settings.iframe) {
                 iframe = $tag('iframe')[0];
-                
+
                 if (frameBorder in iframe) {
                     iframe[frameBorder] = 0;
                 }
@@ -674,193 +676,209 @@
             } else {
                 complete();
             }
-            
+
             if (settings.transition === 'fade') {
                 $box.fadeTo(speed, 1, removeFilter);
             } else {
                 removeFilter();
             }
-		};
-		
-		if (settings.transition === 'fade') {
-			$box.fadeTo(speed, 0, function () {
-				publicMethod.position(0, callback);
-			});
-		} else {
-			publicMethod.position(speed, callback);
-		}
-	};
+        };
 
-	publicMethod.load = function (launched) {
-		var href, setResize, prep = publicMethod.prep;
-		
-		active = true;
-		
-		photo = false;
-		
-		element = $related[index];
-		
-		if (!launched) {
-			makeSettings();
-		}
-		
-		trigger(event_purge);
-		
-		trigger(event_load, settings.onLoad);
-		
-		settings.h = settings.height ?
+        if (settings.transition === 'fade') {
+            $box.fadeTo(speed, 0, function () {
+                publicMethod.position(0, callback);
+            });
+        } else {
+            publicMethod.position(speed, callback);
+        }
+    };
+
+    publicMethod.load = function (launched) {
+        var href, setResize, prep = publicMethod.prep;
+
+        active = true;
+
+        photo = false;
+
+        element = $related[index];
+
+        if (!launched) {
+            makeSettings();
+        }
+
+        trigger(event_purge);
+
+        trigger(event_load, settings.onLoad);
+
+        settings.h = settings.height ?
 				setSize(settings.height, 'y') - loadedHeight - interfaceHeight :
 				settings.innerHeight && setSize(settings.innerHeight, 'y');
-		
-		settings.w = settings.width ?
+
+        settings.w = settings.width ?
 				setSize(settings.width, 'x') - loadedWidth - interfaceWidth :
 				settings.innerWidth && setSize(settings.innerWidth, 'x');
-		
-		// Sets the minimum dimensions for use in image scaling
-		settings.mw = settings.w;
-		settings.mh = settings.h;
-		
-		// Re-evaluate the minimum width and height based on maxWidth and maxHeight values.
-		// If the width or height exceed the maxWidth or maxHeight, use the maximum values instead.
-		if (settings.maxWidth) {
-			settings.mw = setSize(settings.maxWidth, 'x') - loadedWidth - interfaceWidth;
-			settings.mw = settings.w && settings.w < settings.mw ? settings.w : settings.mw;
-		}
-		if (settings.maxHeight) {
-			settings.mh = setSize(settings.maxHeight, 'y') - loadedHeight - interfaceHeight;
-			settings.mh = settings.h && settings.h < settings.mh ? settings.h : settings.mh;
-		}
-		
-		href = settings.href;
-		
+
+        // Sets the minimum dimensions for use in image scaling
+        settings.mw = settings.w;
+        settings.mh = settings.h;
+
+        // Re-evaluate the minimum width and height based on maxWidth and maxHeight values.
+        // If the width or height exceed the maxWidth or maxHeight, use the maximum values instead.
+        if (settings.maxWidth) {
+            settings.mw = setSize(settings.maxWidth, 'x') - loadedWidth - interfaceWidth;
+            settings.mw = settings.w && settings.w < settings.mw ? settings.w : settings.mw;
+        }
+        if (settings.maxHeight) {
+            settings.mh = setSize(settings.maxHeight, 'y') - loadedHeight - interfaceHeight;
+            settings.mh = settings.h && settings.h < settings.mh ? settings.h : settings.mh;
+        }
+
+        href = settings.href;
+
         loadingTimer = setTimeout(function () {
             $loadingOverlay.show();
         }, 100);
-        
-		if (settings.inline) {
-			// Inserts an empty placeholder where inline content is being pulled from.
-			// An event is bound to put inline content back when ColorBox closes or loads new content.
-			$tag(div).hide().insertBefore($(href)[0]).one(event_purge, function () {
-				$(this).replaceWith($loaded.children());
-			});
-			prep($(href));
-		} else if (settings.iframe) {
-			// IFrame element won't be added to the DOM until it is ready to be displayed,
-			// to avoid problems with DOM-ready JS that might be trying to run in that iframe.
-			prep(" ");
-		} else if (settings.html) {
-			prep(settings.html);
-		} else if (isImage(href)) {
-			$(photo = new Image())
+
+        if (settings.inline) {
+            // Inserts an empty placeholder where inline content is being pulled from.
+            // An event is bound to put inline content back when ColorBox closes or loads new content.
+            $tag(div).hide().insertBefore($(href)[0]).one(event_purge, function () {
+                $(this).replaceWith($loaded.children());
+            });
+            prep($(href));
+        } else if (settings.ajaxInline) {
+            var $target = $(settings.inlineTarget);
+
+            if ($target.children().length == 0) {
+                $loadingBay.load(href, settings.data, function (data, status, xhr) {
+                    $target.html(status === 'error' ? $tag(div, 'Error').text('Request unsuccessful: ' + xhr.statusText) : $(this).contents());
+                });
+            }
+
+            // Inserts an empty placeholder where inline content is being pulled from.
+            // An event is bound to put inline content back when ColorBox closes or loads new content.
+            $tag(div).hide().insertBefore($target[0]).one(event_purge, function () {
+                $(this).replaceWith($loaded.children());
+            });
+            prep($target);
+
+        } else if (settings.iframe) {
+            // IFrame element won't be added to the DOM until it is ready to be displayed,
+            // to avoid problems with DOM-ready JS that might be trying to run in that iframe.
+            prep(" ");
+        } else if (settings.html) {
+            prep(settings.html);
+        } else if (isImage(href)) {
+            $(photo = new Image())
 			.addClass(prefix + 'Photo')
 			.error(function () {
-				settings.title = false;
-				prep($tag(div, 'Error').text('This image could not be loaded'));
+			    settings.title = false;
+			    prep($tag(div, 'Error').text('This image could not be loaded'));
 			})
 			.load(function () {
-				var percent;
-				photo.onload = null; //stops animated gifs from firing the onload repeatedly.
-				
-				if (settings.scalePhotos) {
-					setResize = function () {
-						photo.height -= photo.height * percent;
-						photo.width -= photo.width * percent;	
-					};
-					if (settings.mw && photo.width > settings.mw) {
-						percent = (photo.width - settings.mw) / photo.width;
-						setResize();
-					}
-					if (settings.mh && photo.height > settings.mh) {
-						percent = (photo.height - settings.mh) / photo.height;
-						setResize();
-					}
-				}
-				
-				if (settings.h) {
-					photo.style.marginTop = Math.max(settings.h - photo.height, 0) / 2 + 'px';
-				}
-				
-				if ($related[1] && (index < $related.length - 1 || settings.loop)) {
-					photo.style.cursor = 'pointer';
-					photo.onclick = function () {
-                        publicMethod.next();
-                    };
-				}
-				
-				if (isIE) {
-					photo.style.msInterpolationMode = 'bicubic';
-				}
-				
-				setTimeout(function () { // A pause because Chrome will sometimes report a 0 by 0 size otherwise.
-					prep(photo);
-				}, 1);
-			});
-			
-			setTimeout(function () { // A pause because Opera 10.6+ will sometimes not run the onload function otherwise.
-				photo.src = href;
-			}, 1);
-		} else if (href) {
-			$loadingBay.load(href, settings.data, function (data, status, xhr) {
-				prep(status === 'error' ? $tag(div, 'Error').text('Request unsuccessful: ' + xhr.statusText) : $(this).contents());
-			});
-		}
-	};
-        
-	// Navigates to the next page/image in a set.
-	publicMethod.next = function () {
-		if (!active && $related[1] && (index < $related.length - 1 || settings.loop)) {
-			index = getIndex(1);
-			publicMethod.load();
-		}
-	};
-	
-	publicMethod.prev = function () {
-		if (!active && $related[1] && (index || settings.loop)) {
-			index = getIndex(-1);
-			publicMethod.load();
-		}
-	};
+			    var percent;
+			    photo.onload = null; //stops animated gifs from firing the onload repeatedly.
 
-	// Note: to use this within an iframe use the following format: parent.$.fn.colorbox.close();
-	publicMethod.close = function () {
-		if (open && !closing) {
-			
-			closing = true;
-			
-			open = false;
-			
-			trigger(event_cleanup, settings.onCleanup);
-			
-			$window.unbind('.' + prefix + ' .' + event_ie6);
-			
-			$overlay.fadeTo(200, 0);
-			
-			$box.stop().fadeTo(300, 0, function () {
-                 
-				$box.add($overlay).css({'opacity': 1, cursor: 'auto'}).hide();
-				
-				trigger(event_purge);
-				
-				$loaded.remove();
-				
-				setTimeout(function () {
-					closing = false;
-					trigger(event_closed, settings.onClosed);
-				}, 1);
+			    if (settings.scalePhotos) {
+			        setResize = function () {
+			            photo.height -= photo.height * percent;
+			            photo.width -= photo.width * percent;
+			        };
+			        if (settings.mw && photo.width > settings.mw) {
+			            percent = (photo.width - settings.mw) / photo.width;
+			            setResize();
+			        }
+			        if (settings.mh && photo.height > settings.mh) {
+			            percent = (photo.height - settings.mh) / photo.height;
+			            setResize();
+			        }
+			    }
+
+			    if (settings.h) {
+			        photo.style.marginTop = Math.max(settings.h - photo.height, 0) / 2 + 'px';
+			    }
+
+			    if ($related[1] && (index < $related.length - 1 || settings.loop)) {
+			        photo.style.cursor = 'pointer';
+			        photo.onclick = function () {
+			            publicMethod.next();
+			        };
+			    }
+
+			    if (isIE) {
+			        photo.style.msInterpolationMode = 'bicubic';
+			    }
+
+			    setTimeout(function () { // A pause because Chrome will sometimes report a 0 by 0 size otherwise.
+			        prep(photo);
+			    }, 1);
 			});
-		}
-	};
 
-	// A method for fetching the current element ColorBox is referencing.
-	// returns a jQuery object.
-	publicMethod.element = function () {
-		return $(element);
-	};
+            setTimeout(function () { // A pause because Opera 10.6+ will sometimes not run the onload function otherwise.
+                photo.src = href;
+            }, 1);
+        } else if (href) {
+            $loadingBay.load(href, settings.data, function (data, status, xhr) {
+                prep(status === 'error' ? $tag(div, 'Error').text('Request unsuccessful: ' + xhr.statusText) : $(this).contents());
+            });
+        }
+    };
 
-	publicMethod.settings = defaults;
-    
-	// Bind the live event before DOM-ready for maximum performance in IE6 & 7.
-	$('.' + boxElement, document).live('click', function (e) {
+    // Navigates to the next page/image in a set.
+    publicMethod.next = function () {
+        if (!active && $related[1] && (index < $related.length - 1 || settings.loop)) {
+            index = getIndex(1);
+            publicMethod.load();
+        }
+    };
+
+    publicMethod.prev = function () {
+        if (!active && $related[1] && (index || settings.loop)) {
+            index = getIndex(-1);
+            publicMethod.load();
+        }
+    };
+
+    // Note: to use this within an iframe use the following format: parent.$.fn.colorbox.close();
+    publicMethod.close = function () {
+        if (open && !closing) {
+
+            closing = true;
+
+            open = false;
+
+            trigger(event_cleanup, settings.onCleanup);
+
+            $window.unbind('.' + prefix + ' .' + event_ie6);
+
+            $overlay.fadeTo(200, 0);
+
+            $box.stop().fadeTo(300, 0, function () {
+
+                $box.add($overlay).css({ 'opacity': 1, cursor: 'auto' }).hide();
+
+                trigger(event_purge);
+
+                $loaded.remove();
+
+                setTimeout(function () {
+                    closing = false;
+                    trigger(event_closed, settings.onClosed);
+                }, 1);
+            });
+        }
+    };
+
+    // A method for fetching the current element ColorBox is referencing.
+    // returns a jQuery object.
+    publicMethod.element = function () {
+        return $(element);
+    };
+
+    publicMethod.settings = defaults;
+
+    // Bind the live event before DOM-ready for maximum performance in IE6 & 7.
+    $('.' + boxElement, document).live('click', function (e) {
         // ignore non-left-mouse-clicks and clicks modified with ctrl / command, shift, or alt.
         // See: http://jacklmoore.com/notes/click-events/
         if (!(e.which > 1 || e.shiftKey || e.altKey || e.metaKey)) {
@@ -869,7 +887,7 @@
         }
     });
 
-	// Setup ColorBox
-	publicMethod.init();
+    // Setup ColorBox
+    publicMethod.init();
 
-}(jQuery, document, this));
+} (jQuery, document, this));

--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -230,6 +230,15 @@
             $box.removeClass(className + "off " + className + "on");
         }
 	}
+	
+	function loadInline(target) {
+		// Inserts an empty placeholder where inline content is being pulled from.
+		// An event is bound to put inline content back when ColorBox closes or loads new content.
+		$tag(div).hide().insertBefore($(target)[0]).one(event_purge, function () {
+			$(this).replaceWith($loaded.children());
+		});
+		publicMethod.prep($(target));
+	}
 
 	function launch(target) {
 		if (!closing) {
@@ -740,29 +749,18 @@
         }, 100);
         
 		if (settings.inline) {
-			// Inserts an empty placeholder where inline content is being pulled from.
-			// An event is bound to put inline content back when ColorBox closes or loads new content.
-			$tag(div).hide().insertBefore($(href)[0]).one(event_purge, function () {
-				$(this).replaceWith($loaded.children());
-			});
-			prep($(href));
+			loadInline(href);
 		} else if (settings.ajaxInline) {
-			// Get inline target
-			var $target = $(settings.inlineTarget);
-			
 			// Only load once
-			if ($target.children().length == 0) {
+			if ($(settings.inlineTarget).children().length == 0) {
 				$loadingBay.load(href, settings.data, function (data, status, xhr) {
-					$target.html(status === 'error' ? $tag(div, 'Error').text('Request unsuccessful: ' + xhr.statusText) : $(this).contents());
+					$(settings.inlineTarget).html(status === 'error' ? $tag(div, 'Error').text('Request unsuccessful: ' + xhr.statusText) : $(this).contents());
+					loadInline(settings.inlineTarget);
 				});
 			}
-			
-			// Inserts an empty placeholder where inline content is being pulled from.
-			// An event is bound to put inline content back when ColorBox closes or loads new content.
-			$tag(div).hide().insertBefore($target[0]).one(event_purge, function () {
-				$(this).replaceWith($loaded.children());
-			});
-			prep($target);
+			else {
+				loadInline(settings.inlineTarget);
+			}
 		} else if (settings.iframe) {
 			// IFrame element won't be added to the DOM until it is ready to be displayed,
 			// to avoid problems with DOM-ready JS that might be trying to run in that iframe.


### PR DESCRIPTION
Added ajaxInline component to load external resources into an inline element on click. It will only load the resource the first time which allows you to preserve any set values and the target allows you to embed it in a form. Also defers loading external resources until you need them.

example usage:

$(this).colorbox({ ajaxInline: true, inlineTarget: '#inlineTarget', innerWidth: '950px', innerHeight: '550px' });
