### PR TITLE
Add modal option

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -384,7 +384,7 @@
 				// Key Bindings
 				$(document).bind('keydown.' + prefix, function (e) {
 					var key = e.keyCode;
-					if (!settings.modal && open && settings.escKey && key === 27) {
+					if (open && !settings.modal && settings.escKey && key === 27) {
 						e.preventDefault();
 						publicMethod.close();
 					}


### PR DESCRIPTION
When "modal" set to "true", only $.colorbox.close() can close the box. Fixes issue #134
