### PR TITLE
Using box-sizing: border-box is getting to a popular technique with CSS....

### DIFF
--- a/example1/colorbox.css
+++ b/example1/colorbox.css
@@ -2,6 +2,7 @@
     ColorBox Core Style:
     The following CSS is consistent between example themes and should not be altered.
 */
+#colorbox, #colorbox * { box-sizing: content-box; }
 #colorbox, #cboxOverlay, #cboxWrapper{position:absolute; top:0; left:0; z-index:9999; overflow:hidden;}
 #cboxOverlay{position:fixed; width:100%; height:100%;}
 #cboxMiddleLeft, #cboxBottomLeft{clear:left;}


### PR DESCRIPTION
Using box-sizing: border-box is getting to a popular technique with CSS. (See: http://paulirish.com/2012/box-sizing-border-box-ftw/)

If box-sizing: border-box is applied to *, colorbox's display gets cut off on the right side. This is a quick fix to remedy that issue by applying the default value of content-box to the box-sizing property for #colorbox and its descendants.
