### PR TITLE
fixing null $.data(this, colorbox).

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -243,7 +243,7 @@
 			
 			if (settings.rel !== 'nofollow') {
 				$related = $('.' + boxElement).filter(function () {
-					var relRelated = $.data(this, colorbox).rel || this.rel;
+					var relRelated = ($.data(this, colorbox) && $.data(this, colorbox).rel) ? $.data(this, colorbox).rel : this.rel;
 					return (relRelated === settings.rel);
 				});
 				index = $related.index(element);


### PR DESCRIPTION
searching for jQuery the error this produces on google has different "colorbox" errors as the top 4 result pages, currently, so I know it's been a problem for a while. 

whatever the real solution might be to fix $.data being null, this particular call needs to be better protected from nulls, especially since you've already given a sane default.

thanks!

-- dustin potter
