### PR TITLE
made close() aware of settings.speed and settings.transition

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -886,10 +886,11 @@
 			
 			$window.unbind('.' + prefix + ' .' + event_ie6);
 			
-			$overlay.fadeTo(200, 0);
+			if (settings.transition === "none") $overlay.css({'opacity': 0});
+			else $overlay.fadeTo(settings.speed, 0);
 			
-			$box.stop().fadeTo(300, 0, function () {
-				 
+			var cleanup = function() {
+			
 				$box.add($overlay).css({'opacity': 1, cursor: 'auto'}).hide();
 				
 				trigger(event_purge);
@@ -900,7 +901,15 @@
 					closing = false;
 					trigger(event_closed, settings.onClosed);
 				}, 1);
-			});
+			};
+			
+			$box.stop();
+			
+			if (settings.transition === "none") {
+				$box.css({'opacity': 0});
+				cleanup();
+			}
+			else $box.fadeTo(settings.speed + 100, 0, cleanup);
 		}
 	};
 


### PR DESCRIPTION
I am working on an app that is doing _a lot_ of DOM manipulation and wanted to reduce the load by specifying `{speed: 0, transition: "none"}`. This works when colorbox is first displayed, but `close()` is hardcoded to fadeOut. I modified `close()` so that it will obey settings.speed on the fadeOut, and not fadeOut at all if `settings.transition === "none"`
