### PR TITLE
New option for scaling images

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -827,10 +827,10 @@
 				prep($tag(div, 'Error').html(settings.imgError));
 			})
 			.load(function () {
-				var percent;
+				var percent, ratio;
 				photo.onload = null; //stops animated gifs from firing the onload repeatedly.
 				
-				if (settings.scalePhotos) {
+				if (settings.scalePhotos === true || settings.scalePhotos == 'contain') {
 					setResize = function () {
 						photo.height -= photo.height * percent;
 						photo.width -= photo.width * percent;
@@ -843,10 +843,15 @@
 						percent = (photo.height - settings.mh) / photo.height;
 						setResize();
 					}
+				} else if (settings.scalePhotos == 'cover') {
+					ratio = Math.max(settings.mw/photo.width, settings.mh/photo.height);
+					
+					photo.height = photo.height * ratio;
+					photo.width = photo.width * ratio;
 				}
 				
 				if (settings.h) {
-					photo.style.marginTop = Math.max(settings.h - photo.height, 0) / 2 + 'px';
+					photo.style.marginTop = Math.floor(settings.h - photo.height) / 2 + 'px';
 				}
 				
 				if ($related[1] && (settings.loop || $related[index + 1])) {


### PR DESCRIPTION
scalePhotos has now three values/options:

false (off, no changes)
true, 'contain' (added the keyword, else no changes)
'cover' (the images covers the image container)

the "contain" and "cover" keywords were chosen because of the background-size property and behave exactly the same

of course this new option only works if the image container is greater (width, height or both) than the image itself - for example if you set innerWidth/innerHeight to 100%

its also useful to combine this option with "scrolling: false" - else it gets a bit odd
