### PR TITLE
HTML5 compatiblity: data rel

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -187,7 +187,7 @@
 			}
 		}
 		
-		settings.rel = settings.rel || element.rel || 'nofollow';
+		settings.rel = settings.rel || element.rel || $(element).data('rel') || 'nofollow';
 		settings.href = settings.href || $(element).attr('href');
 		settings.title = settings.title || element.title;
 		
@@ -270,7 +270,7 @@
 						relRelated;
 
 					if (data) {
-						relRelated =  data.rel || this.rel;
+						relRelated =  $(this).data('rel') || data.rel || this.rel;
 					}
 					
 					return (relRelated === settings.rel);


### PR DESCRIPTION
as you have stated in #168, the data-rel attribute should be the default behaviour

unfortunately your solution with rel: function() { $(this).data('rel'); } does not work, since settings.rel is filled subsequently with "nofollow" if not rel attribute is found - this hauses that grouping of elements does not work at all

this patch solves this problem, bot not the problem that you can't relate the elements by any attribute/selector you like
