### PR TITLE
Fix to issue #258

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -939,4 +939,4 @@
 
 	publicMethod.settings = defaults;
 
-}(jQuery, document, this));
+}(jQuery, document, window));


### PR DESCRIPTION
Changed the local scoping of the window variable with this to prevent obscure bug in IE7

In some very rare occasions using this as the windows variable causes a memory leak in IE7.
