### PR TITLE
Added data-title attribute to use as lightbox title

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -170,7 +170,8 @@
 	// Assigns function results to their respective properties
 	function makeSettings() {
 		var i,
-			data = $.data(element, colorbox);
+			data = $.data(element, colorbox),
+			title = document.getElementById(element.getAttribute('data-title'));
 		
 		if (data == null) {
 			settings = $.extend({}, defaults);
@@ -189,7 +190,7 @@
 		
 		settings.rel = settings.rel || element.rel || $(element).data('rel') || 'nofollow';
 		settings.href = settings.href || $(element).attr('href');
-		settings.title = settings.title || element.title;
+		settings.title = settings.title || (title && title.innerHTML) || element.title;
 		
 		if (typeof settings.href === "string") {
 			settings.href = $.trim(settings.href);


### PR DESCRIPTION
This feature would let the user specify an element by ID to use as the title of a lightbox using the `data-title` attribute of the link:

``` html
<a href="image.jpg" data-title="the-title">ColorBox link</a>
<p id="the-title">
    <strong>HTML formatted</strong> title for the above link's lightbox.
</p>
```

The idea came up for users that aren't able to create a custom settings.title function but would like HTML formatted titles.
