### PR TITLE
[#292] Fix ClearType bug that appears when opening colorbox for the 2nd time on IE8.

### DIFF
--- a/colorbox/jquery.colorbox.js
+++ b/colorbox/jquery.colorbox.js
@@ -75,7 +75,7 @@
 	event_purge = prefix + '_purge',
 	
 	// Special Handling for IE
-	isIE = !$.support.opacity && !$.support.style, // IE7 & IE8
+	isIE = !$.support.leadingWhitespace, // IE6 to IE8
 	isIE6 = isIE && !window.XMLHttpRequest, // IE6
 	event_ie6 = prefix + '_IE6',
 


### PR DESCRIPTION
The bug was due to the fact that jQuery.support.style is true on IE8, although it
was expected to be false. jQuery.support.leadingWhitespace is used instead, as it is
false from IE6 to IE8. See https://github.com/jackmoore/colorbox/issues/292.
