### PR TITLE
Fixed IE7 crash

### DIFF
--- a/src/jquery.colorbox.js
+++ b/src/jquery.colorbox.js
@@ -587,7 +587,11 @@
 		
 		var callback, speed = settings.transition === "none" ? 0 : settings.speed;
 		
-		$loaded.remove();
+		if (isIE) {
+			$loaded.empty().remove(); // Fix IE7 crash bug
+		} else {
+			$loaded.remove();
+		}
 		$loaded = $tag(div, 'LoadedContent').append(object);
 		
 		function getWidth() {
@@ -894,7 +898,11 @@
 				
 				trigger(event_purge);
 				
-				$loaded.remove();
+				if (isIE) {
+					$loaded.empty().remove(); // Fix IE7 crash bug
+				} else {
+					$loaded.remove();
+				}
 				
 				setTimeout(function () {
 					closing = false;


### PR DESCRIPTION
IE7 crash fix for (some?) jQuery versions, at least jQuery 1.7.x in our development environment (native IE7, not emulated).
