### PR TITLE
use getAttribute('href') on img elements instead of img.href

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -715,7 +715,7 @@
 								src = src.call(i);
 							}
 						} else {
-							src = i.href;
+							src = i.getAttribute('href');
 						}
 
 						if (isImage(src)) {


### PR DESCRIPTION
In the rel-group preloading function, the "href" attribute of a Colorbox image is referenced via `i.href` (where `i` is the image element object). However, at least in Firefox 18 and Chromium 23, the `href` property doesn't appear to be defined for image element objects. So use `getAttribute('href')` instead to get that property.
