### PR TITLE
Extra check to prevent duplicate colorboxes

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -386,7 +386,9 @@
 	// ColorBox's markup needs to be added to the DOM prior to being called
 	// so that the browser will go ahead and load the CSS background images.
 	function appendHTML() {
-		if (!$box && document.body) {
+		var existing = $('#'+colorbox).length;
+		
+		if (!$box && document.body && existing == 0) {
 			init = false;
 
 			$window = $(window);


### PR DESCRIPTION
I had a nasty bug where each time I clicked an element to open a colorbox, it created a new #colorbox and #cboxOverlay in the DOM, so n+1 colorboxes would open for n clicks.  The only way I could find around it was by patching colorbox itself with this simple check.  Hopefully it doesn't break anything else...it seems harmless enough, but it saved the day for our project.  I'm surprised I haven't seen anyone else report this, it must be a weird edge case that we found.

I didn't minify or anything, just changed the main js file.
