### PR TITLE
3 new public methods

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -983,6 +983,24 @@
 			launch($related[index]);
 		}
 	};
+	
+	// jump to specified index
+	publicMethod.setindex = function (val) {
+		if (!active && $related[1] && (index || settings.loop) && ((val+1) <= $related.length) && index != val) {
+			index = val;
+			load();
+		}
+	};
+	
+	// get specified index
+	publicMethod.index = function () {
+		return index;
+	};
+	
+	// returns related elements
+	publicMethod.related = function () {
+		return $related;
+	};
 
 	// Note: to use this within an iframe use the following format: parent.$.fn.colorbox.close();
 	publicMethod.close = function () {


### PR DESCRIPTION
a few needed public methods for external extensions like mentioned in issue #55

setIndex: for opening a colorbox with a specified index (like prev/next but with an index)
index: to read the current numeric index of the opened element
related: to get a collection of all cbox elements (just like "element" but all of them)

since it has changed, this obsoltes pull request #141

these methods are needed to create an external thumbstrip like here:
http://hotel-rieser.com/de/service-info/bildergalerien/?tx_chgallery_pi1%5Bdir%5D=5
