### PR TITLE
Default processing on click image

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -32,6 +32,7 @@
 		opacity: 0.9,
 		preloading: true,
 		className: false,
+                onClickNext: true,
 
 		// alternate image paths for high-res displays
 		retinaImage: false,
@@ -928,9 +929,11 @@
 				
 				if ($related[1] && (settings.loop || $related[index + 1])) {
 					photo.style.cursor = 'pointer';
-					photo.onclick = function () {
-						publicMethod.next();
-					};
+                                        if(settings.onClickNext){
+					    photo.onclick = function () {
+					        publicMethod.next();
+					    };
+                                        }
 				}
 
 				photo.style.width = photo.width + 'px';


### PR DESCRIPTION
I needed to make the next task
By click on right side of img show next img, on left show prev img, i make the event on click img and it work, but standart processing still continue show next img, than I add options to your plugin, if it can be done otherwise, show me plz.

Add ability to disable the default processing on click, add option onClickNext: true, if false it does not show next image.
