### PR TITLE
Fixed crash on Chrome 27

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -891,8 +891,10 @@
 
 			href = retinaUrl(settings, href);
 
-			$(photo = new Image())
-			.addClass(prefix + 'Photo')
+			photoJq = $('<img>');
+			photo = photoJq.get(0);
+
+			photoJq.addClass(prefix + 'Photo')
 			.bind('error',function () {
 				settings.title = false;
 				prep($tag(div, 'Error').html(settings.imgError));


### PR DESCRIPTION
Fixed Colorbox crash on Chrome 27 when clicking image:

Error message: "Uncaught Error: NotFoundError: DOM Exception 8 "
