### PR TITLE
add delay option to colorbox close

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -65,6 +65,7 @@
 		onCleanup: false,
 		onClosed: false,
 		overlayClose: true,
+		closeDelay:1,
 		escKey: true,
 		arrowKey: true,
 		top: false,
@@ -998,22 +999,27 @@
 			trigger(event_cleanup, settings.onCleanup);
 			
 			$window.unbind('.' + prefix);
-			
-			$overlay.fadeTo(settings.fadeOut || 0, 0);
-			
-			$box.stop().fadeTo(settings.fadeOut || 0, 0, function () {
-			
-				$box.add($overlay).css({'opacity': 1, cursor: 'auto'}).hide();
-				
-				trigger(event_purge);
-				
-				$loaded.empty().remove(); // Using empty first may prevent some IE7 issues.
-				
-				setTimeout(function () {
-					closing = false;
-					trigger(event_closed, settings.onClosed);
-				}, 1);
-			});
+
+			setTimeout(function () {
+
+				$overlay.fadeTo(settings.fadeOut || 0, 0);
+
+				$box.stop().fadeTo(settings.fadeOut || 0, 0, function () {
+
+					$box.add($overlay).css({'opacity': 1, cursor: 'auto'}).hide();
+
+					trigger(event_purge);
+
+					$loaded.empty().remove(); // Using empty first may prevent some IE7 issues.
+
+					setTimeout(function () {
+						closing = false;
+						trigger(event_closed, settings.onClosed);
+					}, 1);
+
+				});
+
+			}, settings.closeDelay);
 		}
 	};
 


### PR DESCRIPTION
This might not the best implementation, but adding a `closeDelay` option to colorbox will allow for custom closing animations using the callback options (allowing time for an exit/close animation before firing the fade).

Example: I'm using the animate.css `https://github.com/daneden/animate.css` library with the callback options for open and close transitions. See `http://andrewpulley.com/colorboxdemo/example1/` and click on the elastic and fade transition sections.

Thanks!
