### PR TITLE
Bugfix loading overlay/graphic order

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -407,7 +407,7 @@
 				tabindex: '-1'
 			}).hide();
 			$overlay = $tag(div, "Overlay").hide();
-			$loadingOverlay = $tag(div, "LoadingOverlay").add($tag(div, "LoadingGraphic"));
+			$loadingOverlay = $([$tag('div', "LoadingOverlay")[0],$tag('div', "LoadingGraphic")[0]]);
 			$wrap = $tag(div, "Wrapper");
 			$content = $tag(div, "Content").append(
 				$title = $tag(div, "Title"),


### PR DESCRIPTION
Hi Jack,

Thanks for your plugin. It is excellent!

I bring here a small contribution to fix a bug which appears on Mac Safari with colorbox v1.4.22: the loading overlay elements are inserted in the wrong order in the DOM:

```
<div id="cboxLoadingGraphic"></div>
<div id="cboxLoadingOverlay"></div>
```

As a result, the loading gif is hidden behind the overlay.

After looking at your code, it appears that you use the jQuery `add()` function, which doesn't guarantee the elements order. Taken from the [doc](http://api.jquery.com/add/):

> Do not assume that this method appends the elements to the existing collection in the order they are passed to the .add() method. [...] If the collection consists of elements [...] not in any document, the sort order is **undefined**. To create a jQuery object with elements in a well-defined order, use the $(array_of_DOM_elements) signature.

Regards.
