### PR TITLE
Example4 loading icon is not centered

### DIFF
--- a/example4/colorbox.css
+++ b/example4/colorbox.css
@@ -35,7 +35,7 @@
         #cboxLoadedContent{margin-bottom:20px;}
         #cboxTitle{position:absolute; bottom:0px; left:0; text-align:center; width:100%; color:#999;}
         #cboxCurrent{position:absolute; bottom:0px; left:100px; color:#999;}
-        #cboxLoadingOverlay{background:#fff url(images/loading.gif) no-repeat 5px 5px;}
+        #cboxLoadingOverlay{background:#fff url(images/loading.gif) no-repeat center center;}
 
         /* these elements are buttons, and may need to have additional styles reset to avoid unwanted base styles */
         #cboxPrevious, #cboxNext, #cboxSlideshow, #cboxClose {border:0; padding:0; margin:0; overflow:visible; width:auto; background:none; }


### PR DESCRIPTION
The loading icon positioning is off in example4 as compared to the other themes.
