### PR TITLE
Fixed a bug where events are propagated to document from $events

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -94,6 +94,8 @@
 	event_closed = prefix + '_closed',
 	event_purge = prefix + '_purge',
 
+	events = event_open + ' ' + event_load + ' ' + event_complete + ' ' + event_cleanup + ' ' + event_closed + ' ' + event_purge,
+
 	// Cached jQuery Object Variables
 	$overlay,
 	$box,
@@ -136,6 +138,11 @@
 	requests = 0,
 	previousCSS = {},
 	init;
+
+	// Bind all events on $events and stop propagating them
+	$events.bind(events, function(event) {
+		event.stopPropagation();
+	});
 
 	// ****************
 	// HELPER FUNCTIONS


### PR DESCRIPTION
This is to fix the issue reported in #525. I have tested this on my own site and found that the event handler is executed only once, correctly.
