### PR TITLE
Restore support for rel nofollow

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -242,7 +242,7 @@
 	function getRelated(rel) {
 		index = 0;
 		
-		if (rel && rel !== false) {
+		if (rel && rel !== false && rel !== 'nofollow') {
 			$related = $('.' + boxElement).filter(function () {
 				var options = $.data(this, colorbox);
 				var settings = new Settings(this, options);


### PR DESCRIPTION
The documentation at http://www.jacklmoore.com/colorbox/ still states that rel:nofollow can be used to show un-grouped popups. Better to use rel:false of course, but old projects may be using the old nofollow convention.
