### PR TITLE
Correction of publicMethod.remove()

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -1076,7 +1076,7 @@
 			.removeData(colorbox)
 			.removeClass(boxElement);
 
-		$(document).unbind('click.'+prefix);
+		$(document).unbind('click.'+prefix).unbind('keydown.'+prefix);
 	};
 
 	// A method for fetching the current element Colorbox is referencing.


### PR DESCRIPTION
correction in publicMethod.remove() by adding jQuery unbind call for "keydown" event preventing from having multiple listeners when resetting the colorbox with $.colorbox.remove().
