### PR TITLE
Jump to end of animation in remove()

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -1068,7 +1068,7 @@
 
 		$box.stop();
 		$.colorbox.close();
-		$box.stop().remove();
+		$box.stop(false, true).remove();
 		$overlay.remove();
 		closing = false;
 		$box = null;


### PR DESCRIPTION
In the `remove` public method, `close` is called, followed immediately by calling jQuery `stop` on the lightbox element:

``` javascript
publicMethod.remove = function () {
  if (!$box) { return; }

  $box.stop();
  $.colorbox.close();
  $box.stop().remove();
```

Since `close` depends on the callback function passed to `fadeTo`, and `stop` prevents any callbacks on animations it stops from running, the cleanup is incomplete when using `remove`. For instance, since the `event_closed` isn't fired, the focus trap event on `document` is not unbound, and this results in errors.

I fixed this by passing the `jumpToEnd` parameter to `stop`, which skips to the end of the animation and **does** run the callbacks.

I wasn't sure how you go about minifying the code, let me know if you want me to update the minified version before merging.
