### PR TITLE
Fixing a hardcoded colorbox value

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -353,7 +353,7 @@
 
 		if (!closing) {
 
-			options = $(element).data('colorbox');
+			options = $(element).data(colorbox);
 
 			settings = new Settings(element, options);
 			


### PR DESCRIPTION
When resolving a conflict between two colorbox versions, found this hardcoded value, should use variable `colorbox` instead
