### PR TITLE
Prevent: Error: Uncaught TypeError

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -697,7 +697,7 @@
 					}, 1);
 				}
 
-				if (loadedCallback) {
+				if ($.isFunction(loadedCallback)) {
 					loadedCallback();
 				}
 			},


### PR DESCRIPTION
Prevent: Error: Uncaught TypeError: object is not a function
