### PR TITLE
Bugfix maxHeight after $.colorbox.resize()

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -733,7 +733,7 @@
 				scrolltop = $loaded.scrollTop();
 				$loaded.css({height: "auto"});
 				settings.h = $loaded.height();
-				if (settings.h > settings.mh) settings.h=settings.mh;
+				settings.h = Math.min(settings.h, settings.mh);
 			}
 
 			$loaded.css({height: settings.h});

--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -732,7 +732,7 @@
 			if (!options.innerHeight && !options.height) {
 				scrolltop = $loaded.scrollTop();
 				$loaded.css({height: "auto"});
-				settings.h = Math.min(settings.h, setSize(settings.get('maxHeight'), 'y') - loadedHeight - interfaceHeight);
+				settings.h = Math.min($loaded.height(), setSize(settings.get('maxHeight'), 'y') - loadedHeight - interfaceHeight);
 			}
 
 			$loaded.css({height: settings.h});

--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -733,6 +733,7 @@
 				scrolltop = $loaded.scrollTop();
 				$loaded.css({height: "auto"});
 				settings.h = $loaded.height();
+				if (settings.h > settings.mh) settings.h=settings.mh;
 			}
 
 			$loaded.css({height: settings.h});

--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -732,7 +732,7 @@
 			if (!options.innerHeight && !options.height) {
 				scrolltop = $loaded.scrollTop();
 				$loaded.css({height: "auto"});
-				settings.h = Math.min($loaded.height(), setSize(settings.get('maxHeight'), 'y') - loadedHeight - interfaceHeight);
+				settings.h = Math.min($loaded.height(), setSize(settings.get('maxHeight')||'100%', 'y') - loadedHeight - interfaceHeight);
 			}
 
 			$loaded.css({height: settings.h});

--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -732,8 +732,7 @@
 			if (!options.innerHeight && !options.height) {
 				scrolltop = $loaded.scrollTop();
 				$loaded.css({height: "auto"});
-				settings.h = $loaded.height();
-				settings.h = Math.min(settings.h, settings.mh);
+				settings.h = Math.min($loaded.height(), settings.mh);
 			}
 
 			$loaded.css({height: settings.h});

--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -732,7 +732,7 @@
 			if (!options.innerHeight && !options.height) {
 				scrolltop = $loaded.scrollTop();
 				$loaded.css({height: "auto"});
-				settings.h = Math.min($loaded.height(), settings.mh);
+				settings.h = Math.min(settings.h, setSize(settings.get('maxHeight'), 'y') - loadedHeight - interfaceHeight);
 			}
 
 			$loaded.css({height: settings.h});


### PR DESCRIPTION
Earlier, if I set .colorbox{maxHeight:'95%'...} then colorbox frame gets vertical scrollbar (if content is heighter than frame) but if then I do $.colorbox.resize() my colorbox frame becomes heighter than wrapper page and my maxHeight option is ignored, so this is bugfix for it.
