### PR TITLE
added support for Rails 4.1.4 w/Turbolinks

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -435,7 +435,7 @@
 	// Colorbox's markup needs to be added to the DOM prior to being called
 	// so that the browser will go ahead and load the CSS background images.
 	function appendHTML() {
-		if (!$box && document.body) {
+		if (document.body) {
 			init = false;
 			$window = $(window);
 			$box = $tag(div).attr({
@@ -552,10 +552,6 @@
 	if ($[colorbox]) {
 		return;
 	}
-
-	// Append the HTML when the DOM loads
-	$(appendHTML);
-
 
 	// ****************
 	// PUBLIC FUNCTIONS
@@ -1085,6 +1081,10 @@
 		return $(settings.el);
 	};
 
+  publicMethod.appendHTML = function() {
+		appendHTML();
+	};
+	
 	publicMethod.settings = defaults;
 
 }(jQuery, document, window));


### PR DESCRIPTION
Please merge this for Rails 4 support.  Currently, for those using Rails w/Turbolinks, the page must be refreshed before Colorbox will work.  This has to do with the 'page:change' event.

Again, credit to sydneyitguy/colorbox@11cb088358429c4fb80ced7da0c6b49f7285a084 for the solution.
