### PR TITLE
ensures $box exists within live DOM within appendHTML

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -435,7 +435,7 @@
 	// Colorbox's markup needs to be added to the DOM prior to being called
 	// so that the browser will go ahead and load the CSS background images.
 	function appendHTML() {
-		if (!$box && document.body) {
+		if ((!$box || !$box.parent().length) && document.body) {
 			init = false;
 			$window = $(window);
 			$box = $tag(div).attr({


### PR DESCRIPTION
this is helpful if colorbox's initial markup (rendered on dom ready) is removed by another plugin / ajax call. I'm using Pjax where the `<body>` tag is the container being replaced, this ensures that colorbox's markup is re-rendered if it so happens to be axed.
