### PR TITLE
set 'overflow: auto' on $box in modalDimensions.

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -656,7 +656,8 @@
 		$wrap[0].style.width = $wrap[0].style.height = "9999px";
 		
 		function modalDimensions() {
-			$topBorder[0].style.width = $bottomBorder[0].style.width = $content[0].style.width = (parseInt($box[0].style.width,10) - interfaceWidth)+'px';
+ 			$box.css('overflow', 'auto');
+ 			$topBorder[0].style.width = $bottomBorder[0].style.width = $content[0].style.width = (parseInt($box[0].style.width,10) - interfaceWidth)+'px';
 			$content[0].style.height = $leftBorder[0].style.height = $rightBorder[0].style.height = (parseInt($box[0].style.height,10) - interfaceHeight)+'px';
 		}
 


### PR DESCRIPTION
If you close the colorbox by clicking on the background overlay before
the image inside the box is loaded, overflow on $box remains set to
'hidden', so that the $groupControls are hidden if you re-open the box.
