### PR TITLE
Focus - Allow to open the dialog without changing the current focus

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -68,6 +68,7 @@
 		// accessbility
 		returnFocus: true,
 		trapFocus: true,
+		requestFocus: true,
 
 		// callbacks
 		onOpen: false,
@@ -424,7 +425,9 @@
 
 				$groupControls.add($title).hide();
 
-				$box.focus();
+				if (settings.get('requestFocus')) {
+					$box.focus();
+				}
 
 				if (settings.get('trapFocus')) {
 					// Confine focus to the modal


### PR DESCRIPTION
I use the 'colorbox' library to display validation message but the client doesn't want me to change the current focused element when displaying it
