### PR TITLE
Add callback support to resize method

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -735,7 +735,7 @@
 		});
 	};
 
-	publicMethod.resize = function (options) {
+	publicMethod.resize = function (options, callback) {
 		var scrolltop;
 
 		if (open) {
@@ -771,7 +771,7 @@
 				$loaded.scrollTop(scrolltop);
 			}
 
-			publicMethod.position(settings.get('transition') === "none" ? 0 : settings.get('speed'));
+			publicMethod.position(settings.get('transition') === "none" ? 0 : settings.get('speed'), callback);
 		}
 	};
 


### PR DESCRIPTION
Hi Jack !

It would be great if we could add a callback function to the resize method.

In my case, I have some tooltips to show after the colorbox resize
If I don't wait the resize to finish, the tooltips will get a wrong position 

What do you think ?

Thank you for your help

NB : I know there are already 2 similar PR but they are too old :)
