### PR TITLE
Add settings options for vertical scrolling and horizontal scrolling 

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -28,6 +28,8 @@
 		maxHeight: false,
 		scalePhotos: true,
 		scrolling: true,
+		verticalScrolling: true,
+		horizontalScrolling: true,
 		opacity: 0.9,
 		preloading: true,
 		className: false,
@@ -801,6 +803,8 @@
 		.appendTo($loadingBay.show())// content has to be appended to the DOM for accurate size calculations.
 		.css({width: getWidth(), overflow: settings.get('scrolling') ? 'auto' : 'hidden'})
 		.css({height: getHeight()})// sets the height independently from the width in case the new width influences the value of height.
+		.css({overflowX:settings.get('verticalScrolling') ? 'auto' : 'hidden'})
+		.css({overflowY:settings.get('horizontalScrolling') ? 'auto' : 'hidden'})
 		.prependTo($content);
 
 		$loadingBay.hide();

--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -803,8 +803,8 @@
 		.appendTo($loadingBay.show())// content has to be appended to the DOM for accurate size calculations.
 		.css({width: getWidth(), overflow: settings.get('scrolling') ? 'auto' : 'hidden'})
 		.css({height: getHeight()})// sets the height independently from the width in case the new width influences the value of height.
-		.css({overflowX:settings.get('verticalScrolling') ? 'auto' : 'hidden'})
-		.css({overflowY:settings.get('horizontalScrolling') ? 'auto' : 'hidden'})
+		.css({overflowY:settings.get('verticalScrolling') ? 'auto' : 'hidden'})
+		.css({overflowX:settings.get('horizontalScrolling') ? 'auto' : 'hidden'})
 		.prependTo($content);
 
 		$loadingBay.hide();


### PR DESCRIPTION
Ran into a problem where I needed my colorbox to give me horizontal scrolling but not vertical scrolling. I noticed that the only available setting was `scrolling:true`. This gives the colorbox `overflow:auto`, which does not solve my problem. 

So, I decided to add two optional settings. One for horizontal scrolling and one for vertical scrolling. If either is set to false, the respective axis does not allow for scrolling.
