### PR TITLE
Pass accessibility tests. fixes #765

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -482,13 +482,13 @@
 			$content = $tag(div, "Content").append(
 				$title = $tag(div, "Title"),
 				$current = $tag(div, "Current"),
-				$prev = $('<button type="button"/>').attr({id:prefix+'Previous'}),
-				$next = $('<button type="button"/>').attr({id:prefix+'Next'}),
-				$slideshow = $('<button type="button"/>').attr({id:prefix+'Slideshow'}),
+				$prev = $('<button type="button">previous</button>').attr({id:prefix+'Previous'}),
+				$next = $('<button type="button">next</button>').attr({id:prefix+'Next'}),
+				$slideshow = $('<button type="button">start slideshow</button>').attr({id:prefix+'Slideshow'}),
 				$loadingOverlay
 			);
 
-			$close = $('<button type="button"/>').attr({id:prefix+'Close'});
+			$close = $('<button type="button">close</button>').attr({id:prefix+'Close'});
 
 			$wrap.append( // The 3x3 Grid that makes up Colorbox
 				$tag(div).append(


### PR DESCRIPTION
This is option 1 fix for #765.

The approach here adds button text from colorbox defaults at page load time to avoid the following errors reported by accessibility tests:

* wave.webaim.org:

      A button is empty or has no value text.

* HTML_CodeSniffer WCAG 2.0 Level AAA:

      This button element does not have a name available to an
      accessibility API. Valid names are: title attribute, element
      content.

