### PR TITLE
rel -> data-rel

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -77,7 +77,7 @@
 		onClosed: false,
 
 		rel: function() {
-			return this.rel;
+			return $(this).data('rel');
 		},
 		href: function() {
 			// using this.href would give the absolute url, when the href may have been inteded as a selector (e.g. '#container')


### PR DESCRIPTION
Bad value something for attribute rel on element a: The string something is not a registered keyword.
`<a rel='something'>` - not valid html code in HTML5
`<a data-rel='something'>` - valid html code in HTML5

https://www.w3.org/TR/html5/links.html#linkTypes
http://microformats.org/wiki/existing-rel-values#HTML5_link_type_extensions