### PR TITLE
Add redraw() public method.

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -1051,6 +1051,12 @@
 		}
 	};
 
+	publicMethod.redraw = function () {
+		if (!active && $related[index]) {
+			launch($related[index]);
+		}
+	};
+
 	// Note: to use this within an iframe use the following format: parent.jQuery.colorbox.close();
 	publicMethod.close = function () {
 		if (open && !closing) {

--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -1052,7 +1052,7 @@
 	};
 
 	publicMethod.redraw = function () {
-		if (!active && $related[index]) {
+		if (open && !active && $related[index]) {
 			launch($related[index]);
 		}
 	};


### PR DESCRIPTION
This is necesssary to be able to redraw the colorbox on the current slide to force re-position or resize based on events that are not controlled by dom events. It is not possible to implement such a method from outside the colorbox plugin because it uses internal variables that cannot be accessed from the outter space...