### PR TITLE
docs: Fix simple typo, inteded -> intended

### DIFF
--- a/jquery.colorbox.js
+++ b/jquery.colorbox.js
@@ -80,7 +80,7 @@
 			return this.rel;
 		},
 		href: function() {
-			// using this.href would give the absolute url, when the href may have been inteded as a selector (e.g. '#container')
+			// using this.href would give the absolute url, when the href may have been intended as a selector (e.g. '#container')
 			return $(this).attr('href');
 		},
 		title: function() {


### PR DESCRIPTION
There is a small typo in jquery.colorbox.js.

Should read `intended` rather than `inteded`.

