### PR TITLE
Use `peerDependencies` for jQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"type": "git",
 		"url": "http://github.com/jackmoore/colorbox.git"
 	},
-	"dependencies": {
+	"peerDependencies": {
 		"jquery": ">=1.3.2"
 	}
 }


### PR DESCRIPTION
Would it make sense to specify `jquery` as a `peerDependency` to make sure it matches the version of jQuery the main project installs?